### PR TITLE
test: add custom API provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,18 @@ OPENROUTER_API_KEY=your-openrouter-api-key-here
 # SIDECAR_EXPLORE_MODEL=openrouter/google/gemini-3-flash-preview
 
 # =============================================================================
+# Custom Providers
+# =============================================================================
+
+# Custom providers are configured via `sidecar setup` or by editing
+# ~/.config/sidecar/config.json (customProviders section).
+# API keys for custom providers are stored here, just like built-in providers.
+#
+# Example: after adding "ollama" and "together" as custom providers:
+# OLLAMA_API_KEY=
+# TOGETHER_API_KEY=your-together-api-key-here
+
+# =============================================================================
 # Advanced / Debug
 # =============================================================================
 

--- a/electron/ipc-setup.js
+++ b/electron/ipc-setup.js
@@ -116,6 +116,33 @@ function registerSetupHandlers(ipcMain, getMainWindow) {
     return { status, hints, imported: imported.map(e => e.provider) };
   });
 
+  ipcMain.handle('sidecar:get-custom-providers', () => {
+    const { getCustomProviders } = require('../src/utils/config');
+    return getCustomProviders();
+  });
+
+  ipcMain.handle('sidecar:save-custom-provider', (_event, id, provider) => {
+    try {
+      const { saveCustomProvider } = require('../src/utils/config');
+      saveCustomProvider(id, provider);
+      return { success: true };
+    } catch (err) {
+      logger.error('save-custom-provider handler error', { error: err.message });
+      return { success: false, error: err.message };
+    }
+  });
+
+  ipcMain.handle('sidecar:remove-custom-provider', (_event, id) => {
+    try {
+      const { removeCustomProvider } = require('../src/utils/config');
+      removeCustomProvider(id);
+      return { success: true };
+    } catch (err) {
+      logger.error('remove-custom-provider handler error', { error: err.message });
+      return { success: false, error: err.message };
+    }
+  });
+
   ipcMain.handle('sidecar:fetch-models', async () => {
     try {
       const { readApiKeyValues } = require('../src/utils/api-key-store');

--- a/electron/preload-setup.js
+++ b/electron/preload-setup.js
@@ -20,7 +20,10 @@ contextBridge.exposeInMainWorld('sidecarSetup', {
       'sidecar:save-config',
       'sidecar:get-config',
       'sidecar:get-api-keys',
-      'sidecar:fetch-models'
+      'sidecar:fetch-models',
+      'sidecar:get-custom-providers',
+      'sidecar:save-custom-provider',
+      'sidecar:remove-custom-provider'
     ];
     if (!allowedChannels.includes(channel)) {
       throw new Error(`IPC channel not allowed: ${channel}`);

--- a/electron/setup-ui-keys-script.js
+++ b/electron/setup-ui-keys-script.js
@@ -109,7 +109,84 @@ function buildKeysScript() {
       removeBtn.style.display = 'none'; updateNextState();
     } catch (_e) { statusMsg.textContent = 'Failed to remove'; statusMsg.className = 'status-invalid'; }
     removeBtn.disabled = false;
-  });`;
+  });
+
+  // Custom provider form logic
+  var cpForm = document.getElementById('custom-provider-form');
+  var cpStatusMsg = document.getElementById('cp-status-msg');
+  document.getElementById('add-custom-btn').addEventListener('click', function() {
+    cpForm.style.display = cpForm.style.display === 'none' ? '' : 'none';
+  });
+  document.getElementById('cp-cancel-btn').addEventListener('click', function() {
+    cpForm.style.display = 'none'; cpStatusMsg.textContent = '';
+  });
+  document.getElementById('cp-save-btn').addEventListener('click', async function() {
+    var cpId = document.getElementById('cp-id').value.trim().toLowerCase();
+    var cpName = document.getElementById('cp-name').value.trim();
+    var cpUrl = document.getElementById('cp-url').value.trim();
+    var cpAuth = document.getElementById('cp-auth').value;
+    var cpEnv = document.getElementById('cp-env').value.trim() || (cpId.toUpperCase() + '_API_KEY');
+    if (!cpId || !cpName || !cpUrl) {
+      cpStatusMsg.textContent = 'ID, Name, and Base URL are required';
+      cpStatusMsg.className = 'status-invalid'; return;
+    }
+    try {
+      await window.sidecarSetup.invoke('sidecar:save-custom-provider', cpId, { name: cpName, baseUrl: cpUrl, authType: cpAuth, envVar: cpEnv });
+      var newProv = { id: cpId, name: cpName, description: cpUrl, placeholder: '', custom: true };
+      providers.push(newProv);
+      addCustomProviderCard(newProv);
+      cpForm.style.display = 'none'; cpStatusMsg.textContent = '';
+      document.getElementById('cp-id').value = '';
+      document.getElementById('cp-name').value = '';
+      document.getElementById('cp-url').value = '';
+      document.getElementById('cp-env').value = '';
+    } catch (e) {
+      cpStatusMsg.textContent = e.message || 'Failed to save'; cpStatusMsg.className = 'status-invalid';
+    }
+  });
+
+  function addCustomProviderCard(prov) {
+    var list = document.getElementById('custom-providers-list');
+    var btn = document.createElement('button');
+    btn.className = 'provider-btn'; btn.setAttribute('data-provider', prov.id);
+    btn.innerHTML = '<span class="provider-name">' + prov.name + ' <span class="badge">Custom</span></span>' +
+      '<span class="provider-desc">' + prov.description + '</span>' +
+      '<span class="provider-check" id="check-' + prov.id + '"></span>';
+    btn.addEventListener('click', function() {
+      selectedProvider = prov;
+      document.querySelectorAll('.provider-btn').forEach(function(b) { b.classList.remove('selected'); });
+      btn.classList.add('selected');
+      keySection.classList.add('visible');
+      keyLabel.textContent = prov.name + ' API Key';
+      keyInput.placeholder = prov.placeholder || '';
+      if (keyHints[prov.id]) {
+        keyInput.value = keyHints[prov.id]; keyInput.type = 'text'; keyValid = false;
+        setInputState('valid'); statusMsg.textContent = 'Key configured \\u2714'; statusMsg.className = 'status-valid';
+        removeBtn.style.display = '';
+      } else {
+        keyInput.value = ''; keyInput.type = 'password'; keyValid = false; setInputState(null);
+        statusMsg.textContent = ''; statusMsg.className = ''; removeBtn.style.display = 'none';
+      }
+      eyeBtn.classList.remove('active'); keyInput.focus();
+      helpLink.textContent = '';
+    });
+    list.appendChild(btn);
+  }
+
+  // Load existing custom providers on init
+  (async function() {
+    try {
+      var custom = await window.sidecarSetup.invoke('sidecar:get-custom-providers');
+      if (custom) {
+        Object.keys(custom).forEach(function(id) {
+          var cp = custom[id];
+          var prov = { id: id, name: cp.name, description: cp.baseUrl, placeholder: '', custom: true };
+          providers.push(prov);
+          addCustomProviderCard(prov);
+        });
+      }
+    } catch (_e) {}
+  })();`;
 }
 
 module.exports = { buildKeysScript };

--- a/electron/setup-ui-keys.js
+++ b/electron/setup-ui-keys.js
@@ -12,7 +12,7 @@ const PROVIDERS = [
     id: 'openrouter',
     name: 'OpenRouter',
     description: 'Access all models (Gemini, GPT, Claude, etc.) with one key',
-    placeholder: 'sk-or-v1-...',
+    placeholder: 'your-openrouter-key',
     helpUrl: 'https://openrouter.ai/keys',
     helpLabel: 'openrouter.ai/keys',
     recommended: true
@@ -69,6 +69,28 @@ function buildKeysStepHTML(providers) {
 
     <div class="provider-list" id="provider-list">
       ${providerCards}
+    </div>
+
+    <div id="custom-providers-list"></div>
+
+    <button class="provider-btn add-custom-btn" id="add-custom-btn" type="button">
+      <span class="provider-name">+ Add Custom Provider</span>
+      <span class="provider-desc">Self-hosted LLMs, proxy servers, or alternative providers</span>
+    </button>
+
+    <div class="custom-provider-form" id="custom-provider-form" style="display:none">
+      <label class="field-label">Provider ID <input id="cp-id" type="text" placeholder="e.g. ollama" autocomplete="off"></label>
+      <label class="field-label">Display Name <input id="cp-name" type="text" placeholder="e.g. Ollama (Local)" autocomplete="off"></label>
+      <label class="field-label">Base URL <input id="cp-url" type="text" placeholder="e.g. http://localhost:11434/v1" autocomplete="off"></label>
+      <label class="field-label">Auth Type
+        <select id="cp-auth"><option value="bearer">Bearer Token</option><option value="x-api-key">x-api-key</option><option value="none">None</option></select>
+      </label>
+      <label class="field-label">Env Variable <input id="cp-env" type="text" placeholder="e.g. OLLAMA_API_KEY (auto-generated)" autocomplete="off"></label>
+      <div class="input-row">
+        <button class="test-btn" id="cp-save-btn" type="button">Add Provider</button>
+        <button class="remove-btn" id="cp-cancel-btn" type="button">Cancel</button>
+      </div>
+      <span id="cp-status-msg"></span>
     </div>
 
     <div class="key-section" id="key-section">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-sidecar",
-  "version": "0.4.4",
+  "version": "0.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-sidecar",
-      "version": "0.4.4",
+      "version": "0.4.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -19,6 +19,7 @@
         "zod": "^3.0.0"
       },
       "bin": {
+        "claude-sidecar": "bin/sidecar.js",
         "sidecar": "bin/sidecar.js"
       },
       "devDependencies": {

--- a/src/sidecar/setup.js
+++ b/src/sidecar/setup.js
@@ -10,7 +10,7 @@
 
 const path = require('path');
 const readline = require('readline');
-const { loadConfig, saveConfig, getDefaultAliases, getConfigDir } = require('../utils/config');
+const { loadConfig, saveConfig, getDefaultAliases, getConfigDir, saveCustomProvider } = require('../utils/config');
 const { logger } = require('../utils/logger');
 
 /**
@@ -195,9 +195,39 @@ async function runReadlineSetup() {
     console.log('');
     console.log(`Default model set to: ${chosen}`);
     console.log(`Config created with ${aliasCount} aliases.`);
+
+    // Offer to add a custom provider
+    const addCustom = await askQuestion(rl, 'Add a custom API provider? (y/N): ');
+    if (addCustom.toLowerCase() === 'y') {
+      await runCustomProviderSetup(rl);
+    }
+
     console.log(`Config path: ${path.join(getConfigDir(), 'config.json')}`);
   } finally {
     rl.close();
+  }
+}
+
+/**
+ * Interactive custom provider setup via readline
+ * @param {readline.Interface} rl - Readline interface
+ */
+async function runCustomProviderSetup(rl) {
+  console.log('');
+  console.log('--- Custom Provider Setup ---');
+  const id = await askQuestion(rl, 'Provider ID (e.g. ollama, together): ');
+  if (!id.trim()) { console.log('Skipped.'); return; }
+  const name = await askQuestion(rl, 'Display name: ');
+  const baseUrl = await askQuestion(rl, 'Base URL (e.g. http://localhost:11434/v1): ');
+  if (!baseUrl.trim()) { console.log('Base URL required. Skipped.'); return; }
+  const authType = await askQuestion(rl, 'Auth type (bearer/x-api-key/none) [bearer]: ') || 'bearer';
+  const envVar = await askQuestion(rl, `Env variable [${id.trim().toUpperCase()}_API_KEY]: `) ||
+    `${id.trim().toUpperCase()}_API_KEY`;
+  try {
+    saveCustomProvider(id.trim(), { name: name.trim() || id.trim(), baseUrl: baseUrl.trim(), authType, envVar });
+    console.log(`Custom provider '${id.trim()}' saved.`);
+  } catch (err) {
+    console.log(`Error: ${err.message}`);
   }
 }
 
@@ -253,5 +283,6 @@ module.exports = {
   runInteractiveSetup,
   runReadlineSetup,
   runApiKeySetup,
+  runCustomProviderSetup,
   MODEL_CHOICES,
 };

--- a/src/utils/alias-resolver.js
+++ b/src/utils/alias-resolver.js
@@ -5,7 +5,7 @@
  * extracted from config.js to keep it under the 300-line limit.
  */
 
-const { PROVIDER_ENV_MAP, readApiKeyValues } = require('./api-key-store');
+const { readApiKeyValues, getFullProviderEnvMap } = require('./api-key-store');
 const { logger } = require('./logger');
 
 /**
@@ -24,7 +24,8 @@ function applyDirectApiFallback(model) {
   }
   const direct = model.slice('openrouter/'.length);
   const provider = direct.split('/')[0];
-  const envVar = PROVIDER_ENV_MAP[provider];
+  const fullMap = getFullProviderEnvMap();
+  const envVar = fullMap[provider];
   if (envVar && (process.env[envVar] || persistedKeys[provider])) {
     logger.warn({ msg: 'Using direct provider API (OPENROUTER_API_KEY not set)', original: model, resolved: direct });
     process.stderr.write(

--- a/src/utils/api-key-store.js
+++ b/src/utils/api-key-store.js
@@ -15,6 +15,22 @@ const PROVIDER_ENV_MAP = {
   deepseek: 'DEEPSEEK_API_KEY'
 };
 
+/**
+ * Get the full provider→envVar map (built-in + custom providers)
+ * @returns {object} Merged map of providerId → envVar name
+ */
+function getFullProviderEnvMap() {
+  const { getCustomProviders } = require('./config');
+  const custom = getCustomProviders();
+  const merged = { ...PROVIDER_ENV_MAP };
+  for (const [id, cp] of Object.entries(custom)) {
+    if (!merged[id] && cp.envVar) {
+      merged[id] = cp.envVar;
+    }
+  }
+  return merged;
+}
+
 /** Legacy key names that have been renamed (old -> new) */
 const LEGACY_KEY_NAMES = {
   'GEMINI_API_KEY': 'GOOGLE_GENERATIVE_AI_API_KEY'
@@ -101,12 +117,14 @@ function resolveKeyValue(fileEntries, envVar) {
 
 /**
  * Read API key availability from .env file and process.env
- * @returns {{openrouter: boolean, google: boolean, openai: boolean, anthropic: boolean, deepseek: boolean}}
+ * @returns {object} Map of providerId → boolean (includes custom providers)
  */
 function readApiKeys() {
-  const result = { openrouter: false, google: false, openai: false, anthropic: false, deepseek: false };
+  const fullMap = getFullProviderEnvMap();
+  const result = {};
+  for (const provider of Object.keys(fullMap)) { result[provider] = false; }
   const entries = loadEnvEntries();
-  for (const [provider, envVar] of Object.entries(PROVIDER_ENV_MAP)) {
+  for (const [provider, envVar] of Object.entries(fullMap)) {
     if (resolveKeyValue(entries, envVar)) { result[provider] = true; }
   }
   return result;
@@ -114,12 +132,14 @@ function readApiKeys() {
 
 /**
  * Read API key hints (masked prefixes) for UI display
- * @returns {{openrouter: string|false, google: string|false, openai: string|false, anthropic: string|false, deepseek: string|false}}
+ * @returns {object} Map of providerId → masked string or false
  */
 function readApiKeyHints() {
-  const result = { openrouter: false, google: false, openai: false, anthropic: false, deepseek: false };
+  const fullMap = getFullProviderEnvMap();
+  const result = {};
+  for (const provider of Object.keys(fullMap)) { result[provider] = false; }
   const entries = loadEnvEntries();
-  for (const [provider, envVar] of Object.entries(PROVIDER_ENV_MAP)) {
+  for (const [provider, envVar] of Object.entries(fullMap)) {
     const key = resolveKeyValue(entries, envVar);
     if (key) {
       const visible = key.slice(0, 8);
@@ -137,7 +157,7 @@ function readApiKeyHints() {
 function readApiKeyValues() {
   const result = {};
   const entries = loadEnvEntries();
-  for (const [provider, envVar] of Object.entries(PROVIDER_ENV_MAP)) {
+  for (const [provider, envVar] of Object.entries(getFullProviderEnvMap())) {
     const value = resolveKeyValue(entries, envVar);
     if (value) { result[provider] = value; }
   }
@@ -146,7 +166,8 @@ function readApiKeyValues() {
 
 /** Save an API key for a provider to the .env file */
 function saveApiKey(provider, key) {
-  const envVar = PROVIDER_ENV_MAP[provider];
+  const fullMap = getFullProviderEnvMap();
+  const envVar = fullMap[provider];
   if (!envVar) {
     return { success: false, error: `Unknown provider: ${provider}` };
   }
@@ -196,7 +217,8 @@ function saveApiKey(provider, key) {
 
 /** Remove an API key for a provider from the .env file */
 function removeApiKey(provider) {
-  const envVar = PROVIDER_ENV_MAP[provider];
+  const fullMap = getFullProviderEnvMap();
+  const envVar = fullMap[provider];
   if (!envVar) {
     return { success: false, error: `Unknown provider: ${provider}` };
   }
@@ -240,6 +262,7 @@ module.exports = {
   removeApiKey,
   validateApiKey,
   validateOpenRouterKey,
+  getFullProviderEnvMap,
   PROVIDER_ENV_MAP,
   LEGACY_KEY_NAMES,
   VALIDATION_ENDPOINTS

--- a/src/utils/api-key-validation.js
+++ b/src/utils/api-key-validation.js
@@ -3,6 +3,7 @@
  * Extracted from api-key-store.js to keep modules under 300 lines.
  */
 const https = require('https');
+const http = require('http');
 
 /** Validation endpoints per provider */
 const VALIDATION_ENDPOINTS = {
@@ -31,13 +32,46 @@ const VALIDATION_ENDPOINTS = {
   }
 };
 
+/**
+ * Build a dynamic validation endpoint for a custom provider
+ * @param {object} customProvider - {name, baseUrl, authType, envVar}
+ * @returns {object} Validation endpoint config
+ */
+function buildCustomEndpoint(customProvider) {
+  const baseUrl = customProvider.baseUrl.replace(/\/+$/, '');
+  return {
+    url: `${baseUrl}/models`,
+    authHeader: (k) => {
+      if (customProvider.authType === 'x-api-key') {
+        return { 'x-api-key': k };
+      }
+      if (customProvider.authType === 'none') {
+        return {};
+      }
+      return { 'Authorization': `Bearer ${k}` };
+    }
+  };
+}
+
 /** Validate an API key by making a test request to the provider's API */
 function validateApiKey(provider, key) {
   if (!key || key.trim().length === 0) {
     return Promise.resolve({ valid: false, error: 'API key is required' });
   }
 
-  const endpoint = VALIDATION_ENDPOINTS[provider];
+  let endpoint = VALIDATION_ENDPOINTS[provider];
+  let isCustom = false;
+
+  // If not a built-in provider, check custom providers
+  if (!endpoint) {
+    const { getCustomProviders } = require('./config');
+    const custom = getCustomProviders();
+    if (custom[provider]) {
+      endpoint = buildCustomEndpoint(custom[provider]);
+      isCustom = true;
+    }
+  }
+
   if (!endpoint) {
     return Promise.resolve({ valid: false, error: `Unknown provider: ${provider}` });
   }
@@ -51,15 +85,26 @@ function validateApiKey(provider, key) {
   }
 
   const headers = endpoint.authHeader(trimmedKey);
+  const transport = url.startsWith('http://') ? http : https;
 
   return new Promise((resolve) => {
-    const req = https.get(url, { headers }, (res) => {
+    const req = transport.get(url, { headers }, (res) => {
       res.on('data', () => {});
       res.on('end', () => {
         // Anthropic returns 401 for invalid key, 400/405 for valid key with no body
         if (provider === 'anthropic') {
           if (res.statusCode === 401) {
             resolve({ valid: false, error: 'Invalid API key (401)' });
+          } else {
+            resolve({ valid: true });
+          }
+          return;
+        }
+
+        // Custom providers: be lenient — any non-auth-error means reachable
+        if (isCustom) {
+          if (res.statusCode === 401 || res.statusCode === 403) {
+            resolve({ valid: false, error: `Invalid API key (${res.statusCode})` });
           } else {
             resolve({ valid: true });
           }

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -52,6 +52,9 @@ function getConfigPath() {
   return path.join(getConfigDir(), 'config.json');
 }
 
+/** Built-in provider IDs that cannot be overridden by custom providers */
+const BUILTIN_PROVIDERS = ['openrouter', 'google', 'openai', 'anthropic', 'deepseek'];
+
 /** @returns {object|null} Parsed config data, or null if missing/invalid */
 function loadConfig() {
   const configPath = getConfigPath();
@@ -251,6 +254,50 @@ function tryResolveModel(modelArg) {
   }
 }
 
+/**
+ * Get custom providers from config.json
+ * @returns {object} Map of providerId → {name, baseUrl, authType, envVar}
+ */
+function getCustomProviders() {
+  const config = loadConfig();
+  return (config && config.customProviders) || {};
+}
+
+/**
+ * Save a custom provider definition to config.json
+ * @param {string} id - Provider ID (e.g. 'ollama')
+ * @param {{name: string, baseUrl: string, authType: string, envVar: string}} provider
+ * @throws {Error} If id collides with a built-in provider
+ */
+function saveCustomProvider(id, provider) {
+  if (BUILTIN_PROVIDERS.includes(id.toLowerCase())) {
+    throw new Error(`Cannot override built-in provider '${id}'.`);
+  }
+  if (!id || !provider.name || !provider.baseUrl) {
+    throw new Error('Provider id, name, and baseUrl are required.');
+  }
+  const config = loadConfig() || { aliases: {} };
+  if (!config.customProviders) { config.customProviders = {}; }
+  config.customProviders[id.toLowerCase()] = {
+    name: provider.name,
+    baseUrl: provider.baseUrl.replace(/\/+$/, ''),
+    authType: provider.authType || 'bearer',
+    envVar: provider.envVar || `${id.toUpperCase()}_API_KEY`
+  };
+  saveConfig(config);
+}
+
+/**
+ * Remove a custom provider from config.json
+ * @param {string} id - Provider ID to remove
+ */
+function removeCustomProvider(id) {
+  const config = loadConfig();
+  if (!config || !config.customProviders) { return; }
+  delete config.customProviders[id.toLowerCase()];
+  saveConfig(config);
+}
+
 /** Build OpenCode provider.models config from sidecar aliases.
  * @returns {object} e.g. { openrouter: { models: { "x-ai/grok-4.1-fast": {}, ... } } } */
 function buildProviderModels() {
@@ -269,6 +316,17 @@ function buildProviderModels() {
       providers[providerID] = { models: {} };
     }
     providers[providerID].models[modelID] = {};
+  }
+
+  // Merge custom providers with their baseUrl
+  const custom = getCustomProviders();
+  for (const [id, cp] of Object.entries(custom)) {
+    if (!providers[id]) {
+      providers[id] = { models: {} };
+    }
+    if (cp.baseUrl) {
+      providers[id].baseUrl = cp.baseUrl;
+    }
   }
 
   return providers;
@@ -296,4 +354,8 @@ module.exports = {
   formatAliasNames,
   tryResolveModel,
   buildProviderModels,
+  getCustomProviders,
+  saveCustomProvider,
+  removeCustomProvider,
+  BUILTIN_PROVIDERS,
 };

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -242,7 +242,16 @@ function validateApiKey(model) {
   }
 
   const provider = model.split('/')[0].toLowerCase();
-  const providerInfo = PROVIDER_KEY_MAP[provider];
+  let providerInfo = PROVIDER_KEY_MAP[provider];
+
+  // Check custom providers if not in built-in map
+  if (!providerInfo) {
+    const { getCustomProviders } = require('./config');
+    const custom = getCustomProviders();
+    if (custom[provider]) {
+      providerInfo = { key: custom[provider].envVar, name: custom[provider].name };
+    }
+  }
 
   if (!providerInfo) {
     return { valid: true };

--- a/tests/config-fallback.test.js
+++ b/tests/config-fallback.test.js
@@ -5,15 +5,17 @@
  * and persisted keys from api-key-store.
  */
 
+const MOCK_PROVIDER_ENV_MAP = {
+  openrouter: 'OPENROUTER_API_KEY',
+  google: 'GOOGLE_GENERATIVE_AI_API_KEY',
+  openai: 'OPENAI_API_KEY',
+  anthropic: 'ANTHROPIC_API_KEY',
+  deepseek: 'DEEPSEEK_API_KEY',
+};
 jest.mock('../src/utils/api-key-store', () => ({
-  PROVIDER_ENV_MAP: {
-    openrouter: 'OPENROUTER_API_KEY',
-    google: 'GOOGLE_GENERATIVE_AI_API_KEY',
-    openai: 'OPENAI_API_KEY',
-    anthropic: 'ANTHROPIC_API_KEY',
-    deepseek: 'DEEPSEEK_API_KEY',
-  },
+  PROVIDER_ENV_MAP: MOCK_PROVIDER_ENV_MAP,
   readApiKeyValues: jest.fn(),
+  getFullProviderEnvMap: jest.fn(() => ({ ...MOCK_PROVIDER_ENV_MAP })),
 }));
 jest.mock('../src/utils/logger', () => ({
   logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
@@ -55,14 +57,9 @@ describe('applyDirectApiFallback with persisted keys', () => {
     // Re-require config to pick up env changes
     jest.resetModules();
     jest.mock('../src/utils/api-key-store', () => ({
-      PROVIDER_ENV_MAP: {
-        openrouter: 'OPENROUTER_API_KEY',
-        google: 'GOOGLE_GENERATIVE_AI_API_KEY',
-        openai: 'OPENAI_API_KEY',
-        anthropic: 'ANTHROPIC_API_KEY',
-        deepseek: 'DEEPSEEK_API_KEY',
-      },
+      PROVIDER_ENV_MAP: MOCK_PROVIDER_ENV_MAP,
       readApiKeyValues: jest.fn(),
+      getFullProviderEnvMap: jest.fn(() => ({ ...MOCK_PROVIDER_ENV_MAP })),
     }));
     jest.mock('../src/utils/logger', () => ({
       logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },


### PR DESCRIPTION
Enable users to define custom API providers (self-hosted LLMs, proxy servers, alternative providers) via config.json and the setup wizard.

- config.js: CRUD for customProviders in config.json
- api-key-store.js: dynamic provider→envVar map merging built-in + custom
- api-key-validation.js: HTTP/HTTPS validation for custom provider endpoints
- validators.js: custom provider lookup in API key validation
- alias-resolver.js: use dynamic env map for direct API fallback
- Electron UI: "Add Custom Provider" form with IPC handlers
- CLI setup: readline-based custom provider creation flow
- .env.example: document custom provider env vars

All 1477 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Support for configuring and managing custom API providers through the setup interface and CLI.
  * Ability to add, remove, and configure custom provider details including ID, name, base URL, and authentication type.
  * API key validation and persistent storage for custom providers.
  * Custom providers integrate seamlessly alongside built-in providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->