### PR TITLE
fix: 6 verified bugs cherry-picked from PR #9

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -15,7 +15,7 @@ if [ -n "$HEAD_SHA" ] && [ "$HEAD_SHA" = "$CACHED_SHA" ]; then
   echo "Tests already passed for $HEAD_SHA — skipping."
 else
   echo "Running full test suite (unit + integration) before push..."
-  npm run test:all
+  npm run test:all || exit 1
 fi
 
 echo "Checking for dependency vulnerabilities..."

--- a/electron/ipc-setup.js
+++ b/electron/ipc-setup.js
@@ -99,21 +99,28 @@ function registerSetupHandlers(ipcMain, getMainWindow) {
   });
 
   ipcMain.handle('sidecar:get-api-keys', () => {
-    const { readApiKeys, readApiKeyHints, saveApiKey } = require('../src/utils/api-key-store');
-    const { importFromAuthJson } = require('../src/utils/auth-json');
-    const status = readApiKeys();
-    const hints = readApiKeyHints();
+    try {
+      const { readApiKeys, readApiKeyHints, saveApiKey } = require('../src/utils/api-key-store');
+      const { importFromAuthJson } = require('../src/utils/auth-json');
+      const status = readApiKeys();
+      const hints = readApiKeyHints();
 
-    // Auto-import keys from auth.json that sidecar doesn't have yet
-    const { imported } = importFromAuthJson(status);
-    for (const entry of imported) {
-      saveApiKey(entry.provider, entry.key);
-      status[entry.provider] = true;
-      const visible = entry.key.slice(0, 8);
-      hints[entry.provider] = visible + '\u2022'.repeat(Math.max(0, Math.min(entry.key.length - 8, 12)));
+      // Auto-import keys from auth.json that sidecar doesn't have yet
+      const { imported } = importFromAuthJson(status);
+      for (const entry of imported) {
+        const result = saveApiKey(entry.provider, entry.key);
+        if (result && result.success !== false) {
+          status[entry.provider] = true;
+          const visible = entry.key.slice(0, 8);
+          hints[entry.provider] = visible + '\u2022'.repeat(Math.max(0, Math.min(entry.key.length - 8, 12)));
+        }
+      }
+
+      return { status, hints, imported: imported.map(e => e.provider) };
+    } catch (err) {
+      logger.error('get-api-keys handler error', { error: err.message });
+      return { status: {}, hints: {}, imported: [] };
     }
-
-    return { status, hints, imported: imported.map(e => e.provider) };
   });
 
   ipcMain.handle('sidecar:fetch-models', async () => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -47,12 +47,26 @@ function parseArgs(argv) {
     const arg = argv[i];
 
     if (arg.startsWith('--')) {
-      const key = arg.slice(2);
+      let key = arg.slice(2);
       const next = argv[i + 1];
+
+      // Handle --key=value syntax
+      let inlineValue;
+      const eqIdx = key.indexOf('=');
+      if (eqIdx !== -1) {
+        inlineValue = key.slice(eqIdx + 1);
+        key = key.slice(0, eqIdx);
+      }
 
       // Boolean flags (no value expected)
       if (isBooleanFlag(key)) {
         result[key] = true;
+        continue;
+      }
+
+      // If --key=value was used, use the inline value directly
+      if (inlineValue !== undefined) {
+        result[key] = parseValue(key, inlineValue);
         continue;
       }
 

--- a/src/sidecar/setup-window.js
+++ b/src/sidecar/setup-window.js
@@ -29,13 +29,13 @@ function launchSetupWindow() {
       SIDECAR_MODE: 'setup'
     };
 
-    const debugPort = process.env.SIDECAR_DEBUG_PORT || '9222';
-    logger.info('Launching setup window', { debugPort });
+    const debugPort = process.env.SIDECAR_DEBUG_PORT;
+    const args = debugPort
+      ? [`--remote-debugging-port=${debugPort}`, mainPath]
+      : [mainPath];
+    logger.info('Launching setup window', { debugPort: debugPort || 'disabled' });
 
-    const proc = spawn(electronPath, [
-      `--remote-debugging-port=${debugPort}`,
-      mainPath
-    ], {
+    const proc = spawn(electronPath, args, {
       env,
       stdio: ['ignore', 'pipe', 'pipe']
     });

--- a/src/utils/api-key-validation.js
+++ b/src/utils/api-key-validation.js
@@ -60,6 +60,8 @@ function validateApiKey(provider, key) {
         if (provider === 'anthropic') {
           if (res.statusCode === 401) {
             resolve({ valid: false, error: 'Invalid API key (401)' });
+          } else if (res.statusCode >= 500 || res.statusCode === 429) {
+            resolve({ valid: false, error: `Server error (${res.statusCode})` });
           } else {
             resolve({ valid: true });
           }
@@ -74,6 +76,10 @@ function validateApiKey(provider, key) {
           resolve({ valid: false, error: `Unexpected response (${res.statusCode})` });
         }
       });
+    });
+    req.setTimeout(10000, () => {
+      req.destroy();
+      resolve({ valid: false, error: 'Request timed out' });
     });
     req.on('error', (err) => {
       resolve({ valid: false, error: err.message });

--- a/tests/api-key-store-validation.test.js
+++ b/tests/api-key-store-validation.test.js
@@ -184,6 +184,42 @@ describe('api-key-store validation', () => {
       expect(result).toEqual({ valid: false, error: 'Invalid API key (401)' });
     });
 
+    it('should treat anthropic 429 as invalid (rate limited)', async () => {
+      const mockResponse = {
+        statusCode: 429,
+        on: jest.fn((event, cb) => {
+          if (event === 'data') { cb('Rate limited'); }
+          if (event === 'end') { cb(); }
+          return mockResponse;
+        })
+      };
+      https.get.mockImplementation((_url, _opts, cb) => {
+        cb(mockResponse);
+        return { on: jest.fn(), setTimeout: jest.fn(), destroy: jest.fn() };
+      });
+
+      const result = await validateApiKey('anthropic', 'sk-ant-ratelimited');
+      expect(result).toEqual({ valid: false, error: 'Server error (429)' });
+    });
+
+    it('should treat anthropic 500 as invalid (server error)', async () => {
+      const mockResponse = {
+        statusCode: 500,
+        on: jest.fn((event, cb) => {
+          if (event === 'data') { cb('Internal error'); }
+          if (event === 'end') { cb(); }
+          return mockResponse;
+        })
+      };
+      https.get.mockImplementation((_url, _opts, cb) => {
+        cb(mockResponse);
+        return { on: jest.fn(), setTimeout: jest.fn(), destroy: jest.fn() };
+      });
+
+      const result = await validateApiKey('anthropic', 'sk-ant-servererror');
+      expect(result).toEqual({ valid: false, error: 'Server error (500)' });
+    });
+
     it('should validate deepseek key using correct endpoint', async () => {
       let capturedUrl;
       let capturedHeaders;

--- a/tests/api-key-store-validation.test.js
+++ b/tests/api-key-store-validation.test.js
@@ -52,7 +52,7 @@ describe('api-key-store validation', () => {
       };
       https.get.mockImplementation((_url, _opts, cb) => {
         cb(mockResponse);
-        return { on: jest.fn() };
+        return { on: jest.fn(), setTimeout: jest.fn(), destroy: jest.fn() };
       });
 
       const result = await validateApiKey('openrouter', 'sk-or-valid');
@@ -70,7 +70,7 @@ describe('api-key-store validation', () => {
       };
       https.get.mockImplementation((_url, _opts, cb) => {
         cb(mockResponse);
-        return { on: jest.fn() };
+        return { on: jest.fn(), setTimeout: jest.fn(), destroy: jest.fn() };
       });
 
       const result = await validateApiKey('openrouter', 'sk-or-bad');
@@ -79,7 +79,7 @@ describe('api-key-store validation', () => {
 
     it('should resolve invalid for network error', async () => {
       https.get.mockImplementation((_url, _opts, _cb) => {
-        const req = { on: jest.fn() };
+        const req = { on: jest.fn(), setTimeout: jest.fn(), destroy: jest.fn() };
         setTimeout(() => {
           const errCall = req.on.mock.calls.find(c => c[0] === 'error');
           if (errCall) { errCall[1](new Error('Network error')); }
@@ -122,7 +122,7 @@ describe('api-key-store validation', () => {
       };
       https.get.mockImplementation((_url, _opts, cb) => {
         cb(mockResponse);
-        return { on: jest.fn() };
+        return { on: jest.fn(), setTimeout: jest.fn(), destroy: jest.fn() };
       });
 
       const result = await validateApiKey('openrouter', 'sk-or-forbidden');
@@ -140,7 +140,7 @@ describe('api-key-store validation', () => {
       };
       https.get.mockImplementation((_url, _opts, cb) => {
         cb(mockResponse);
-        return { on: jest.fn() };
+        return { on: jest.fn(), setTimeout: jest.fn(), destroy: jest.fn() };
       });
 
       const result = await validateApiKey('openrouter', 'sk-or-500');
@@ -159,7 +159,7 @@ describe('api-key-store validation', () => {
       };
       https.get.mockImplementation((_url, _opts, cb) => {
         cb(mockResponse);
-        return { on: jest.fn() };
+        return { on: jest.fn(), setTimeout: jest.fn(), destroy: jest.fn() };
       });
 
       const result = await validateApiKey('anthropic', 'sk-ant-valid');
@@ -177,7 +177,7 @@ describe('api-key-store validation', () => {
       };
       https.get.mockImplementation((_url, _opts, cb) => {
         cb(mockResponse);
-        return { on: jest.fn() };
+        return { on: jest.fn(), setTimeout: jest.fn(), destroy: jest.fn() };
       });
 
       const result = await validateApiKey('anthropic', 'sk-ant-bad');
@@ -199,7 +199,7 @@ describe('api-key-store validation', () => {
         capturedUrl = url;
         capturedHeaders = opts.headers;
         cb(mockResponse);
-        return { on: jest.fn() };
+        return { on: jest.fn(), setTimeout: jest.fn(), destroy: jest.fn() };
       });
 
       const result = await validateApiKey('deepseek', 'sk-deepseek-valid');
@@ -221,7 +221,7 @@ describe('api-key-store validation', () => {
       https.get.mockImplementation((url, _opts, cb) => {
         capturedUrl = url;
         cb(mockResponse);
-        return { on: jest.fn() };
+        return { on: jest.fn(), setTimeout: jest.fn(), destroy: jest.fn() };
       });
 
       await validateApiKey('google', 'AIza-test-key');

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -348,6 +348,28 @@ describe('CLI Argument Parser', () => {
         expect(result['no-ui']).toBe(true);
       });
     });
+
+    describe('--key=value syntax', () => {
+      it('should parse --model=gemini as model: "gemini"', () => {
+        const result = parseArgs(['start', '--model=gemini', '--prompt', 'test']);
+        expect(result.model).toBe('gemini');
+      });
+
+      it('should parse --timeout=30 as numeric', () => {
+        const result = parseArgs(['start', '--timeout=30']);
+        expect(result.timeout).toBe(30);
+      });
+
+      it('should handle values containing equals signs', () => {
+        const result = parseArgs(['start', '--model=google/gemini-2.5-flash']);
+        expect(result.model).toBe('google/gemini-2.5-flash');
+      });
+
+      it('should still support --model gemini (space-separated)', () => {
+        const result = parseArgs(['start', '--model', 'gemini']);
+        expect(result.model).toBe('gemini');
+      });
+    });
   });
 
   describe('validateStartArgs', () => {

--- a/tests/sidecar/setup-window.test.js
+++ b/tests/sidecar/setup-window.test.js
@@ -54,13 +54,34 @@ describe('setup-window', () => {
 
     expect(spawn).toHaveBeenCalled();
     const spawnArgs = spawn.mock.calls[0];
-    expect(spawnArgs[1][0]).toContain('--remote-debugging-port=');
-    expect(spawnArgs[1][1]).toContain('main.js');
+    // Debug port is opt-in: without SIDECAR_DEBUG_PORT, only main.js is passed
+    expect(spawnArgs[1][0]).toContain('main.js');
 
     const env = spawnArgs[2].env;
     expect(env.SIDECAR_MODE).toBe('setup');
 
     expect(result.success).toBe(true);
+  });
+
+  it('should pass --remote-debugging-port when SIDECAR_DEBUG_PORT is set', async () => {
+    process.env.SIDECAR_DEBUG_PORT = '9333';
+    spawn.mockClear();
+    spawn.mockReturnValue(mockProcess);
+
+    const promise = launchSetupWindow();
+
+    const dataCallback = mockProcess.stdout.on.mock.calls.find(c => c[0] === 'data')[1];
+    dataCallback('{"status":"complete"}\n');
+
+    const closeCallback = mockProcess.on.mock.calls.find(c => c[0] === 'close')[1];
+    closeCallback(0);
+
+    await promise;
+
+    const spawnArgs = spawn.mock.calls[0];
+    expect(spawnArgs[1][0]).toBe('--remote-debugging-port=9333');
+    expect(spawnArgs[1][1]).toContain('main.js');
+    delete process.env.SIDECAR_DEBUG_PORT;
   });
 
   it('should parse enriched JSON with default model and keyCount', async () => {


### PR DESCRIPTION
## Summary

Cherry-picked and independently verified 6 bug fixes identified during review of #9. Each bug was reproduced before fixing.

- **api-key-validation**: Anthropic 429/5xx incorrectly resolved as `{valid: true}`
- **api-key-validation**: No HTTP timeout on validation requests (hangs forever)
- **setup-window**: Remote debug port 9222 always enabled, now opt-in via `SIDECAR_DEBUG_PORT`
- **ipc-setup**: `get-api-keys` handler has no error handling, `saveApiKey` failures silently ignored
- **cli**: `--key=value` syntax parsed as `{"model=gemini": true}` instead of `{"model": "gemini"}`
- **pre-push hook**: Test failures don't block push (script exits 0 due to `npm audit || echo` fallback)

## What was NOT included

The auto-skills framework, activity monitoring hooks, and other feature work from #9 were not included. This PR is strictly bug fixes for existing code.

## Test plan

- [x] All 6 bugs independently reproduced before fixing
- [x] Full test suite passes (1645 tests, 0 failures)
- [x] Lint clean (no new errors)
- [x] New test coverage for `--key=value` CLI syntax (4 tests)
- [x] New test coverage for Anthropic 429/5xx rejection (2 tests)
- [x] Updated setup-window tests for opt-in debug port behavior
- [x] Code review via superpowers:code-reviewer (no critical issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI argument parser now supports inline key-value syntax (e.g., `--key=value`)
  * Remote debugging port is now configurable and optional

* **Bug Fixes**
  * API key validation now handles server errors and request timeouts
  * API key handler includes error recovery and returns safe defaults on failure

* **Chores**
  * Pre-push hook updated to enforce test suite passing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->