### PR TITLE
ci: replace Code Rabbit with Claude auto-review workflow

### DIFF
--- a/.github/codex-audit-agents.md
+++ b/.github/codex-audit-agents.md
@@ -1,0 +1,38 @@
+# AGENTS.md - Codex Audit Role
+
+You are acting as a second-opinion auditor of an automated PR review produced by Claude Code.
+
+## Your Role
+
+Audit the existing review comments on this PR. Do NOT perform a fresh, independent code review.
+
+## What To Do
+
+1. Read all existing review comments left by Claude Code (the `github-actions[bot]` user)
+2. For each finding: confirm if valid, or flag as a false positive with reasoning
+3. Identify meaningful gaps: security issues, logic errors, or missed edge cases that the review overlooked
+4. If you agree with the review and find no gaps, say so briefly
+
+## What NOT To Do
+
+- Do not nitpick style, formatting, naming, or whitespace
+- Do not repeat findings already covered by the existing review
+- Do not perform a general code review of the entire diff
+- Do not comment on test coverage unless a critical path is untested
+- Keep your response concise: only comment when you have substantive input
+
+## Output Format
+
+Structure your review as:
+
+### Confirmed Findings
+- List any findings from Claude's review that you agree with (brief)
+
+### Disputed Findings
+- Any findings you believe are false positives, with reasoning
+
+### Gaps Found
+- Substantive issues the original review missed (security, logic, edge cases)
+
+### Verdict
+One line: "Review looks solid" or "Review has gaps that should be addressed"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -52,6 +52,26 @@ jobs:
         with:
           claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
 
+  codex-audit:
+    needs: auto-review
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Override AGENTS.md with audit-scoped instructions
+        run: cp .github/codex-audit-agents.md AGENTS.md
+
+      - name: Trigger Codex review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --body "@codex review"
+
   claude-assist:
     if: >
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,6 +36,22 @@ jobs:
           plugins: |
             pr-review-toolkit@claude-code-plugins
 
+  security-review:
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 2
+
+      - uses: anthropics/claude-code-security-review@main
+        with:
+          claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+
   claude-assist:
     if: >
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,6 +1,8 @@
 name: Claude Code
 
 on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -9,18 +11,15 @@ on:
     types: [opened, assigned]
 
 concurrency:
-  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  group: claude-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:
-  claude:
-    if: >
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+  auto-review:
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write
@@ -36,4 +35,27 @@ jobs:
 
           plugins: |
             pr-review-toolkit@claude-code-plugins
-            security-guidance@claude-code-plugins
+
+  claude-assist:
+    if: >
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          plugin_marketplaces: |
+            https://github.com/anthropics/claude-code.git
+
+          plugins: |
+            pr-review-toolkit@claude-code-plugins


### PR DESCRIPTION
## Summary
- Split single `claude` job into two: `auto-review` (automatic on PR events) and `claude-assist` (@claude mentions)
- Added `pull_request` trigger for automatic reviews on open/push/ready_for_review
- Draft PRs are skipped in auto-review
- Bumped `contents` permission to `write` so Claude can push suggested fixes

### Plugin research findings
Analyzed all plugins from both Anthropic marketplaces before finalizing:
- **Kept `pr-review-toolkit`**: 6-agent review suite (code-reviewer, code-simplifier, comment-analyzer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer)
- **Dropped `code-review`**: Overlaps with pr-review-toolkit (both have a code-reviewer agent)
- **Dropped `security-guidance`**: PreToolUse hook that only fires when Claude edits files locally. In a GitHub Actions context, Claude reviews diffs, not edits files, so the hook never triggers.
- **Dropped `semgrep`**: Does not exist in either marketplace repo
- **Dropped second marketplace** (`claude-plugins-official`): Not needed since all kept plugins are in `claude-code-plugins`

## Test plan
- [ ] Verify workflow syntax is valid (YAML parses correctly)
- [ ] Open a test PR to confirm `auto-review` job triggers
- [ ] Comment `@claude` on an issue to confirm `claude-assist` job triggers
- [ ] Verify draft PRs do not trigger `auto-review`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated pull request review workflow to trigger on opened, synchronized, and ready-for-review events.
  * Optimized workflow concurrency handling to prioritize pull request processing.
  * Updated repository permissions for improved review automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->