### PR TITLE
fix: guard husky prepare script for non-dev installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "generate-docs": "node scripts/generate-docs.js",
     "generate-docs:check": "node scripts/generate-docs.js --check",
     "validate-docs": "node scripts/validate-docs.js --full",
-    "prepare": "husky"
+    "prepare": "[ -d .git ] && husky || true"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.0",


### PR DESCRIPTION
## Problem

When users install sidecar globally via:

```
npm install -g https://github.com/jrenaldi79/sidecar
```

npm runs the `prepare` script as part of installation. Since `husky` is a devDependency, it isn't present in a global install context — causing the install to fail immediately with a missing module error, before sidecar is usable at all.

## Fix

Guard the `prepare` script so husky only runs when inside a git checkout:

```json
"prepare": "[ -d .git ] && husky || true"
```

This means:
- **Dev installs** (cloned repo): husky installs normally
- **Global installs** (no `.git` dir): the script exits cleanly

This is the standard pattern recommended for projects that support both development and end-user installs. No behavior change for contributors.