### PR TITLE
fix: normalize Claude Code MCP types to OpenCode's local/remote schema

### DIFF
--- a/src/opencode-client.js
+++ b/src/opencode-client.js
@@ -306,29 +306,43 @@ function buildServerOptions(options = {}) {
   // Build config object for SDK
   const config = {};
   if (options.mcp) {
-    // Normalize MCP configs for OpenCode SDK format.
-    // Claude Desktop uses {command: "cmd", args: ["a","b"], env: {...}}
-    // OpenCode expects  {type: "local", enabled: true, command: ["cmd","a","b"], env: {...}}
-    // Key differences:
-    //   1. type: "local" (discriminated union, required)
-    //   2. enabled: true (required boolean)
-    //   3. command: array that includes the binary AND args (merged)
+    // Normalize MCP configs for OpenCode's discriminated union format.
+    //
+    // OpenCode accepts exactly two type values (ConfigInvalidError otherwise):
+    //   { type: "local",  enabled: true, command: ["cmd", ...args] }
+    //   { type: "remote", enabled: true, url: "https://..." }
+    //
+    // Input formats we handle:
+    //   Claude Code internal : { type: "stdio", command: "cmd", args: [...] }
+    //   Claude Desktop       : { command: "cmd", args: [...] }   (no type field)
+    //   Claude Code remote   : { type: "http",  url: "..." }
+    //                          { type: "sse",   url: "..." }
+    //   Already normalized   : { type: "local"|"remote", ... }  → pass through
+    //
+    // Note: OpenCode's "local" schema does NOT support an `env` field.
+    // Environment variables from the source config are intentionally dropped;
+    // MCP servers inherit the parent process environment which is sufficient.
     const normalized = {};
     for (const [name, serverConfig] of Object.entries(options.mcp)) {
-      if (serverConfig.command && !serverConfig.type) {
-        // Claude Desktop format → OpenCode format
+      const t = serverConfig.type;
+      if (t === 'stdio' || (!t && serverConfig.command)) {
+        // stdio process (Claude Code or Claude Desktop format) → local
         const cmd = typeof serverConfig.command === 'string' ? serverConfig.command : String(serverConfig.command);
         const args = Array.isArray(serverConfig.args) ? serverConfig.args : [];
-        // Note: OpenCode's "local" schema does NOT support an `env` field.
-        // Environment variables from the Claude Desktop config are intentionally
-        // dropped here. The MCP servers inherit the parent process environment
-        // which is usually sufficient.
         normalized[name] = {
           type: 'local',
           enabled: true,
           command: [cmd, ...args]
         };
+      } else if (t === 'http' || t === 'sse') {
+        // HTTP/SSE remote server → remote
+        normalized[name] = {
+          type: 'remote',
+          enabled: true,
+          url: serverConfig.url
+        };
       } else {
+        // Already in OpenCode format (type: "local"|"remote") or unknown — pass through
         normalized[name] = serverConfig;
       }
     }

--- a/tests/opencode-client-cowork.test.js
+++ b/tests/opencode-client-cowork.test.js
@@ -166,3 +166,87 @@ describe('buildServerOptions provider model sync', () => {
     expect(opts.config.model).toBe('openrouter/x-ai/grok-4.1-fast');
   });
 });
+
+describe('buildServerOptions MCP type normalization', () => {
+  it('normalizes Claude Desktop format (no type) to local', () => {
+    const opts = buildServerOptions({
+      mcp: { myserver: { command: 'npx', args: ['-y', '@my/server'] } }
+    });
+    expect(opts.config.mcp.myserver).toEqual({
+      type: 'local',
+      enabled: true,
+      command: ['npx', '-y', '@my/server']
+    });
+  });
+
+  it('normalizes type: "stdio" (Claude Code internal format) to local', () => {
+    const opts = buildServerOptions({
+      mcp: { myserver: { type: 'stdio', command: 'node', args: ['server.js'] } }
+    });
+    expect(opts.config.mcp.myserver).toEqual({
+      type: 'local',
+      enabled: true,
+      command: ['node', 'server.js']
+    });
+  });
+
+  it('normalizes type: "http" to remote', () => {
+    const opts = buildServerOptions({
+      mcp: { remote: { type: 'http', url: 'https://example.com/mcp' } }
+    });
+    expect(opts.config.mcp.remote).toEqual({
+      type: 'remote',
+      enabled: true,
+      url: 'https://example.com/mcp'
+    });
+  });
+
+  it('normalizes type: "sse" to remote', () => {
+    const opts = buildServerOptions({
+      mcp: { remote: { type: 'sse', url: 'https://example.com/sse' } }
+    });
+    expect(opts.config.mcp.remote).toEqual({
+      type: 'remote',
+      enabled: true,
+      url: 'https://example.com/sse'
+    });
+  });
+
+  it('passes through already-normalized local config unchanged', () => {
+    const already = { type: 'local', enabled: true, command: ['node', 'srv.js'] };
+    const opts = buildServerOptions({ mcp: { s: already } });
+    expect(opts.config.mcp.s).toEqual(already);
+  });
+
+  it('passes through already-normalized remote config unchanged', () => {
+    const already = { type: 'remote', enabled: true, url: 'https://example.com' };
+    const opts = buildServerOptions({ mcp: { s: already } });
+    expect(opts.config.mcp.s).toEqual(already);
+  });
+
+  it('handles multiple servers with mixed input formats', () => {
+    const opts = buildServerOptions({
+      mcp: {
+        desktop: { command: 'npx', args: ['-y', '@pkg/mcp'] },
+        codeMcp: { type: 'stdio', command: 'node', args: ['s.js'] },
+        httpRemote: { type: 'http', url: 'https://api.example.com/mcp' },
+        sseRemote: { type: 'sse', url: 'https://api.example.com/sse' },
+      }
+    });
+    expect(opts.config.mcp.desktop.type).toBe('local');
+    expect(opts.config.mcp.codeMcp.type).toBe('local');
+    expect(opts.config.mcp.httpRemote.type).toBe('remote');
+    expect(opts.config.mcp.sseRemote.type).toBe('remote');
+  });
+
+  it('handles stdio server with no args', () => {
+    const opts = buildServerOptions({
+      mcp: { minimal: { type: 'stdio', command: '/usr/bin/mcp-server' } }
+    });
+    expect(opts.config.mcp.minimal).toEqual({
+      type: 'local',
+      enabled: true,
+      command: ['/usr/bin/mcp-server']
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Every sidecar session fails immediately if the user has any MCP servers configured in Claude Code — which is essentially everyone using sidecar in a real setup.

When sidecar inherits MCP configs from the parent Claude Code session via `mcp-discovery.js` (`src/utils/mcp-discovery.js`), those configs arrive in Claude Code's internal format:

- Local stdio processes: `{ type: "stdio", command: "...", args: [...] }`
- Remote HTTP servers: `{ type: "http", url: "..." }`
- Remote SSE servers: `{ type: "sse", url: "..." }`

OpenCode v1.2.20's Go binary uses a **discriminated union** for its MCP config and only recognizes two `type` values: `"local"` (stdio process) and `"remote"` (HTTP/SSE). Anything else — including `"stdio"`, `"http"`, and `"sse"` — fails schema validation and returns a `ConfigInvalidError` before the session is even created.

## Root Cause

The normalization block in `buildServerOptions()` (`src/opencode-client.js`, lines 317–334) only handled one input format:

```js
// Before: only handled Claude Desktop format (no type field)
if (serverConfig.command && !serverConfig.type) {
  // Claude Desktop format → OpenCode local
  normalized[name] = { type: 'local', enabled: true, command: [cmd, ...args] };
} else {
  normalized[name] = serverConfig; // ← blind passthrough — type:"stdio" passed through unmodified
}
```

The blind `else` passthrough meant that configs discovered from Claude Code (which always have a `type` field set to `"stdio"`, `"http"`, or `"sse"`) were forwarded to OpenCode unchanged and immediately rejected.

## Fix

Extend the normalization to handle all input formats explicitly (`src/opencode-client.js`):

```js
const t = serverConfig.type;
if (t === 'stdio' || (!t && serverConfig.command)) {
  // Claude Code or Claude Desktop stdio process → local
  normalized[name] = { type: 'local', enabled: true, command: [cmd, ...args] };
} else if (t === 'http' || t === 'sse') {
  // Claude Code HTTP/SSE remote → remote
  normalized[name] = { type: 'remote', enabled: true, url: serverConfig.url };
} else {
  // Already in OpenCode format (type: "local"|"remote") → pass through
  normalized[name] = serverConfig;
}
```

The `enabled: true` field is required by OpenCode's schema on both variants and is carried through for remote servers as it already was for local.

## Tests

8 new unit tests added to `tests/opencode-client-cowork.test.js` covering:
- Claude Desktop format (no type) → `local`
- Claude Code `type: "stdio"` → `local`
- Claude Code `type: "http"` → `remote`
- Claude Code `type: "sse"` → `remote`
- Already-normalized `type: "local"` → pass through
- Already-normalized `type: "remote"` → pass through
- Mixed multi-server configs
- stdio server with no args