### PR TITLE
fix: guard husky prepare script for non-dev installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "generate-docs": "node scripts/generate-docs.js",
     "generate-docs:check": "node scripts/generate-docs.js --check",
     "validate-docs": "node scripts/validate-docs.js --full",
-    "prepare": "husky"
+    "prepare": "[ -d .git ] && husky || true"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.0",


### PR DESCRIPTION
Recreated from #26 (fork PR) so CI workflows have secret access.

Original PR by @dstude.