### PR TITLE
security: restrict sidecar workspace boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,12 @@ tests/screenshots/*
 # Sidecar session data (user-specific)
 .claude/sidecar_sessions/
 
+# Local agent skill links
+.claude/skills/
+.codex/skills/
+.cursor/skills/
+.gemini/skills/
+
 # Agent instruction files (local development only)
 CLAUDE.md
 GEMINI.md

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,7 +7,21 @@
 # 4. Auto-regenerate doc sections (auto-stages CLAUDE.md if changed)
 # 5. CLAUDE.md drift warning
 
-npx lint-staged
+if ! command -v node >/dev/null 2>&1; then
+  for node_dir in /opt/homebrew/bin /usr/local/bin; do
+    if [[ -x "$node_dir/node" ]]; then
+      export PATH="$node_dir:$PATH"
+      break
+    fi
+  done
+fi
+
+command -v node >/dev/null 2>&1 || {
+  echo "husky pre-commit: node is not on PATH" >&2
+  exit 1
+}
+
+lint-staged
 
 node scripts/check-secrets.js
 node scripts/check-file-sizes.js

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,6 +4,20 @@
 # 1. Full test suite (skipped if tests already passed for this commit)
 # 2. npm audit (warn only)
 
+if ! command -v npm >/dev/null 2>&1; then
+  for node_dir in /opt/homebrew/bin /usr/local/bin; do
+    if [[ -x "$node_dir/npm" ]]; then
+      export PATH="$node_dir:$PATH"
+      break
+    fi
+  done
+fi
+
+command -v npm >/dev/null 2>&1 || {
+  echo "husky pre-push: npm is not on PATH" >&2
+  exit 1
+}
+
 # Check if tests already passed for the current HEAD commit
 HEAD_SHA=$(git rev-parse HEAD 2>/dev/null)
 CACHED_SHA=""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,7 @@ evals/
 | `utils/shared-server.js` | Manages a single shared OpenCode server for MCP sessions. | `SharedServerManager()` |
 | `utils/sidecar-boundaries.js` |  | `parseAllowedRoots()`, `validateProjectPath()`, `validateSessionDir()`, `validateSubagentParent()`, `validateSidecarSessionsRoot()` |
 | `utils/sidecar-env.js` |  | `buildChildProcessEnv()` |
-| `utils/sidecar-session-boundaries.js` |  | `validateSidecarSessionsRoot()`, `ensureSidecarSessionDir()`, `validateSidecarSessionDir()`, `validateSidecarSubagentSessionDir()`, `validateSidecarSessionMetadata()` |
+| `utils/sidecar-session-boundaries.js` |  | `validateSidecarSessionsRoot()`, `ensureSidecarSessionDir()`, `validateSidecarSessionDir()`, `ensureSidecarSubagentSessionDir()`, `validateSidecarSubagentsRoot()` |
 | `utils/start-helpers.js` | Start Command Helpers | `resolveModelFromArgs()`, `validateFallbackModel()` |
 | `utils/thinking-validators.js` | Thinking Level Validators | `MODEL_THINKING_SUPPORT()`, `getSupportedThinkingLevels()`, `validateThinkingLevel()` |
 | `utils/updater.js` | @type {import('update-notifier').UpdateNotifier|null} | `initUpdateCheck()`, `getUpdateInfo()`, `notifyUpdate()`, `performUpdate()` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,7 @@ evals/
 | `utils/shared-server.js` | Manages a single shared OpenCode server for MCP sessions. | `SharedServerManager()` |
 | `utils/sidecar-boundaries.js` |  | `parseAllowedRoots()`, `validateProjectPath()`, `validateSessionDir()`, `validateSubagentParent()`, `validateSidecarSessionsRoot()` |
 | `utils/sidecar-env.js` |  | `buildChildProcessEnv()` |
-| `utils/sidecar-session-boundaries.js` |  | `validateSidecarSessionsRoot()`, `validateSidecarSessionDir()`, `validateSidecarSubagentSessionDir()`, `validateSidecarSessionMetadata()`, `resolveContainedSessionFile()` |
+| `utils/sidecar-session-boundaries.js` |  | `validateSidecarSessionsRoot()`, `ensureSidecarSessionDir()`, `validateSidecarSessionDir()`, `validateSidecarSubagentSessionDir()`, `validateSidecarSessionMetadata()` |
 | `utils/start-helpers.js` | Start Command Helpers | `resolveModelFromArgs()`, `validateFallbackModel()` |
 | `utils/thinking-validators.js` | Thinking Level Validators | `MODEL_THINKING_SUPPORT()`, `getSupportedThinkingLevels()`, `validateThinkingLevel()` |
 | `utils/updater.js` | @type {import('update-notifier').UpdateNotifier|null} | `initUpdateCheck()`, `getUpdateInfo()`, `notifyUpdate()`, `performUpdate()` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ src/
 ├── prompts/
 │   └── cowork-agent-prompt.js  # Cowork Agent Prompt
 ├── sidecar/
-│   ├── context-builder.js  # Context Builder Module
+│   ├── context-builder.js  # Resolve a session file, optionally requiring an exact match.
 │   ├── continue.js  # Load previous session data (metadata, summary, conversation)
 │   ├── crash-handler.js  # Crash Handler - Updates metadata to 'error' on uncaught exceptions
 │   ├── interactive.js  # Check if Electron is available (lazy loading guard)
@@ -99,7 +99,7 @@ src/
 │   └── start.js  # Generate a unique 8-character hex task ID
 ├── subagents/
 │   ├── codex-event-normalizer.js  # Parse a single Codex JSONL line.
-│   └── codex-runner.js  # Map Sidecar agent types onto Codex sandbox modes.
+│   └── codex-runner.js  # Start a Codex-backed subagent and return once the subprocess is running.
 ├── utils/
 │   ├── agent-mapping.js  # * All OpenCode native agent names (lowercase)
 │   ├── alias-resolver.js  # Alias Resolver Utilities
@@ -119,6 +119,9 @@ src/
 │   ├── server-setup.js  # Server Setup Utilities
 │   ├── session-lock.js  # Atomic session lock files to prevent concurrent resume/continue.
 │   ├── shared-server.js  # Manages a single shared OpenCode server for MCP sessions.
+│   ├── sidecar-boundaries.js
+│   ├── sidecar-env.js
+│   ├── sidecar-session-boundaries.js
 │   ├── start-helpers.js  # Start Command Helpers
 │   ├── thinking-validators.js  # Thinking Level Validators
 │   ├── updater.js  # @type {import('update-notifier').UpdateNotifier|null}
@@ -216,7 +219,7 @@ evals/
 | `session-manager.js` | * Session status constants | `createSession()`, `updateSession()`, `getSession()`, `saveConversation()`, `saveSummary()` |
 | `session.js` | Session Resolver | `encodeProjectPath()`, `decodeProjectPath()`, `getSessionDirectory()`, `getSessionId()`, `resolveSession()` |
 | `prompts/cowork-agent-prompt.js` | Cowork Agent Prompt | `buildCoworkAgentPrompt()` |
-| `sidecar/context-builder.js` | Context Builder Module | `buildContext()`, `parseDuration()`, `resolveSessionFile()`, `applyContextFilters()`, `findCoworkSession()` |
+| `sidecar/context-builder.js` | Resolve a session file, optionally requiring an exact match. | `buildContext()`, `parseDuration()`, `resolveSessionFile()`, `resolveExactSessionFile()`, `applyContextFilters()` |
 | `sidecar/continue.js` | Load previous session data (metadata, summary, conversation) | `loadPreviousSession()`, `buildContinuationContext()`, `createContinueSessionMetadata()`, `continueSidecar()` |
 | `sidecar/crash-handler.js` | Crash Handler - Updates metadata to 'error' on uncaught exceptions | `installCrashHandler()` |
 | `sidecar/interactive.js` | Check if Electron is available (lazy loading guard) | `getElectronPath()`, `checkElectronAvailable()`, `buildElectronEnv()`, `handleElectronProcess()`, `runInteractive()` |
@@ -228,7 +231,7 @@ evals/
 | `sidecar/setup.js` | Sidecar Setup Wizard | `addAlias()`, `createDefaultConfig()`, `detectApiKeys()`, `runInteractiveSetup()`, `runReadlineSetup()` |
 | `sidecar/start.js` | Generate a unique 8-character hex task ID | `generateTaskId()`, `createSessionMetadata()`, `buildMcpConfig()`, `checkElectronAvailable()`, `runInteractive()` |
 | `subagents/codex-event-normalizer.js` | Parse a single Codex JSONL line. | `parseCodexJsonLine()`, `normalizeCodexEvent()`, `getFinalSummary()` |
-| `subagents/codex-runner.js` | Map Sidecar agent types onto Codex sandbox modes. | `runCodexSubagent()`, `startCodexSubagent()`, `resolveSandboxMode()`, `addRolePreamble()`, `assertCodexAvailable()` |
+| `subagents/codex-runner.js` | Start a Codex-backed subagent and return once the subprocess is running. | `runCodexSubagent()`, `startCodexSubagent()`, `resolveSandboxMode()`, `addRolePreamble()`, `assertCodexAvailable()` |
 | `utils/agent-mapping.js` | * All OpenCode native agent names (lowercase) | `PRIMARY_AGENTS()`, `OPENCODE_AGENTS()`, `HEADLESS_SAFE_AGENTS()`, `mapAgentToOpenCode()`, `isValidAgent()` |
 | `utils/alias-resolver.js` | Alias Resolver Utilities | `applyDirectApiFallback()`, `autoRepairAlias()` |
 | `utils/api-key-store.js` | Maps provider IDs to environment variable names | `getEnvPath()`, `loadEnvEntries()`, `readApiKeys()`, `readApiKeyHints()`, `readApiKeyValues()` |
@@ -247,6 +250,9 @@ evals/
 | `utils/server-setup.js` | Server Setup Utilities | `DEFAULT_PORT()`, `isPortInUse()`, `getPortPid()`, `killPortProcess()`, `ensurePortAvailable()` |
 | `utils/session-lock.js` | Atomic session lock files to prevent concurrent resume/continue. | `acquireLock()`, `releaseLock()`, `isLockStale()`, `isPidAlive()` |
 | `utils/shared-server.js` | Manages a single shared OpenCode server for MCP sessions. | `SharedServerManager()` |
+| `utils/sidecar-boundaries.js` |  | `parseAllowedRoots()`, `validateProjectPath()`, `validateSessionDir()`, `validateSubagentParent()`, `validateSidecarSessionDir()` |
+| `utils/sidecar-env.js` |  | `buildChildProcessEnv()` |
+| `utils/sidecar-session-boundaries.js` |  | `validateSidecarSessionDir()`, `validateSidecarSessionMetadata()` |
 | `utils/start-helpers.js` | Start Command Helpers | `resolveModelFromArgs()`, `validateFallbackModel()` |
 | `utils/thinking-validators.js` | Thinking Level Validators | `MODEL_THINKING_SUPPORT()`, `getSupportedThinkingLevels()`, `validateThinkingLevel()` |
 | `utils/updater.js` | @type {import('update-notifier').UpdateNotifier|null} | `initUpdateCheck()`, `getUpdateInfo()`, `notifyUpdate()`, `performUpdate()` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,9 @@ src/
 │   ├── setup-window.js  # Setup Window Launcher
 │   ├── setup.js  # Sidecar Setup Wizard
 │   └── start.js  # Generate a unique 8-character hex task ID
+├── subagents/
+│   ├── codex-event-normalizer.js  # Parse a single Codex JSONL line.
+│   └── codex-runner.js  # Map Sidecar agent types onto Codex sandbox modes.
 ├── utils/
 │   ├── agent-mapping.js  # * All OpenCode native agent names (lowercase)
 │   ├── alias-resolver.js  # Alias Resolver Utilities
@@ -224,6 +227,8 @@ evals/
 | `sidecar/setup-window.js` | Setup Window Launcher | `launchSetupWindow()` |
 | `sidecar/setup.js` | Sidecar Setup Wizard | `addAlias()`, `createDefaultConfig()`, `detectApiKeys()`, `runInteractiveSetup()`, `runReadlineSetup()` |
 | `sidecar/start.js` | Generate a unique 8-character hex task ID | `generateTaskId()`, `createSessionMetadata()`, `buildMcpConfig()`, `checkElectronAvailable()`, `runInteractive()` |
+| `subagents/codex-event-normalizer.js` | Parse a single Codex JSONL line. | `parseCodexJsonLine()`, `normalizeCodexEvent()`, `getFinalSummary()` |
+| `subagents/codex-runner.js` | Map Sidecar agent types onto Codex sandbox modes. | `runCodexSubagent()`, `startCodexSubagent()`, `resolveSandboxMode()`, `addRolePreamble()`, `assertCodexAvailable()` |
 | `utils/agent-mapping.js` | * All OpenCode native agent names (lowercase) | `PRIMARY_AGENTS()`, `OPENCODE_AGENTS()`, `HEADLESS_SAFE_AGENTS()`, `mapAgentToOpenCode()`, `isValidAgent()` |
 | `utils/alias-resolver.js` | Alias Resolver Utilities | `applyDirectApiFallback()`, `autoRepairAlias()` |
 | `utils/api-key-store.js` | Maps provider IDs to environment variable names | `getEnvPath()`, `loadEnvEntries()`, `readApiKeys()`, `readApiKeyHints()`, `readApiKeyValues()` |
@@ -403,5 +408,6 @@ GEMINI.md and AGENTS.md are symlinks to CLAUDE.md -- no sync needed.
 - [docs/troubleshooting.md](docs/troubleshooting.md)
 - [docs/electron-testing.md](docs/electron-testing.md) - CDP patterns
 - [docs/jsdoc-setup.md](docs/jsdoc-setup.md) - JSDoc, `.d.ts` generation
+- [docs/research/2026-03-16-openai-codex-auth.md](docs/research/2026-03-16-openai-codex-auth.md) - Research on OpenAI/Codex auth reuse and product boundaries
 - [evals/README.md](evals/README.md) - Agentic eval system
 - [docs/plans/index.md](docs/plans/index.md) - Design plans

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,9 +250,9 @@ evals/
 | `utils/server-setup.js` | Server Setup Utilities | `DEFAULT_PORT()`, `isPortInUse()`, `getPortPid()`, `killPortProcess()`, `ensurePortAvailable()` |
 | `utils/session-lock.js` | Atomic session lock files to prevent concurrent resume/continue. | `acquireLock()`, `releaseLock()`, `isLockStale()`, `isPidAlive()` |
 | `utils/shared-server.js` | Manages a single shared OpenCode server for MCP sessions. | `SharedServerManager()` |
-| `utils/sidecar-boundaries.js` |  | `parseAllowedRoots()`, `validateProjectPath()`, `validateSessionDir()`, `validateSubagentParent()`, `validateSidecarSessionDir()` |
+| `utils/sidecar-boundaries.js` |  | `parseAllowedRoots()`, `validateProjectPath()`, `validateSessionDir()`, `validateSubagentParent()`, `validateSidecarSessionsRoot()` |
 | `utils/sidecar-env.js` |  | `buildChildProcessEnv()` |
-| `utils/sidecar-session-boundaries.js` |  | `validateSidecarSessionDir()`, `validateSidecarSessionMetadata()` |
+| `utils/sidecar-session-boundaries.js` |  | `validateSidecarSessionsRoot()`, `validateSidecarSessionDir()`, `validateSidecarSubagentSessionDir()`, `validateSidecarSessionMetadata()`, `resolveContainedSessionFile()` |
 | `utils/start-helpers.js` | Start Command Helpers | `resolveModelFromArgs()`, `validateFallbackModel()` |
 | `utils/thinking-validators.js` | Thinking Level Validators | `MODEL_THINKING_SUPPORT()`, `getSupportedThinkingLevels()`, `validateThinkingLevel()` |
 | `utils/updater.js` | @type {import('update-notifier').UpdateNotifier|null} | `initUpdateCheck()`, `getUpdateInfo()`, `notifyUpdate()`, `performUpdate()` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,7 +251,7 @@ evals/
 | `utils/session-lock.js` | Atomic session lock files to prevent concurrent resume/continue. | `acquireLock()`, `releaseLock()`, `isLockStale()`, `isPidAlive()` |
 | `utils/shared-server.js` | Manages a single shared OpenCode server for MCP sessions. | `SharedServerManager()` |
 | `utils/sidecar-boundaries.js` |  | `parseAllowedRoots()`, `validateProjectPath()`, `validateSessionDir()`, `validateSubagentParent()`, `validateSidecarSessionsRoot()` |
-| `utils/sidecar-env.js` |  | `buildChildProcessEnv()` |
+| `utils/sidecar-env.js` |  | `buildChildProcessEnv()`, `buildMcpServerEnvironment()` |
 | `utils/sidecar-session-boundaries.js` |  | `validateSidecarSessionsRoot()`, `ensureSidecarSessionDir()`, `validateSidecarSessionDir()`, `ensureSidecarSubagentSessionDir()`, `validateSidecarSubagentsRoot()` |
 | `utils/start-helpers.js` | Start Command Helpers | `resolveModelFromArgs()`, `validateFallbackModel()` |
 | `utils/thinking-validators.js` | Thinking Level Validators | `MODEL_THINKING_SUPPORT()`, `getSupportedThinkingLevels()`, `validateThinkingLevel()` |

--- a/bin/sidecar.js
+++ b/bin/sidecar.js
@@ -150,6 +150,7 @@ async function handleStart(args) {
     noMcp: args['no-mcp'],
     excludeMcp: args['exclude-mcp'],
     coworkProcess: args['cowork-process'],
+    includeContext: args['include-context'] === true && args['no-context'] !== true,
     position: args.position
   });
 }

--- a/docs/plans/temporary-local-machine-setup.md
+++ b/docs/plans/temporary-local-machine-setup.md
@@ -1,0 +1,200 @@
+# Temporary Note: Use A Local Sidecar Checkout Machine-Wide
+
+This is a personal setup note for running Sidecar from a local checkout instead of `claude-sidecar@latest`.
+
+Use this when setting up another Mac so Claude Code, Claude Desktop/Cowork, and shell commands all use the same local Sidecar repo.
+
+## Goal
+
+Make all of these resolve to a local checkout:
+
+- `sidecar` in normal terminal shells
+- Claude Code MCP registration
+- Claude Desktop / Cowork MCP registration
+- Claude skill lookup
+- Repo-local `.claude/skills/sidecar` symlinks in projects that keep their own skill trees
+
+## Assumptions
+
+- macOS
+- Homebrew Node installed at `/opt/homebrew/bin/node`
+- local Sidecar repo cloned somewhere on disk
+- Claude Code uses `~/.claude.json`
+- Claude Desktop uses `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+## 1. Choose your local Sidecar checkout
+
+Example:
+
+```bash
+export SIDECAR_REPO="$HOME/Documents/GitHub/sidecar"
+```
+
+Confirm the CLI entrypoint exists:
+
+```bash
+test -f "$SIDECAR_REPO/bin/sidecar.js"
+```
+
+## 2. Create a stable launcher
+
+Create a user-level launcher so every integration points to one stable path:
+
+```bash
+mkdir -p "$HOME/.local/bin"
+cat > "$HOME/.local/bin/sidecar" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exec /opt/homebrew/bin/node "$HOME/Documents/GitHub/sidecar/bin/sidecar.js" "$@"
+EOF
+chmod 755 "$HOME/.local/bin/sidecar"
+```
+
+If your checkout is not at `$HOME/Documents/GitHub/sidecar`, edit the path in the script.
+
+## 3. Put `~/.local/bin` last in `.zshrc`
+
+Add this near the end of `~/.zshrc` so it wins over an older Homebrew or npm-installed `sidecar`:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Open a new shell, then verify:
+
+```bash
+zsh -ic 'command -v sidecar'
+zsh -ic 'sidecar --version'
+```
+
+Expected:
+
+- `command -v sidecar` returns `~/.local/bin/sidecar`
+- `sidecar --version` returns the local checkout's version
+
+## 4. Point Claude Code MCP at the launcher
+
+Update `~/.claude.json` so Sidecar uses the launcher instead of `npx ...@latest`.
+
+Desired entry:
+
+```json
+{
+  "mcpServers": {
+    "sidecar": {
+      "command": "/Users/<you>/.local/bin/sidecar",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+If a `sidecar` entry already exists, replace it.
+
+## 5. Point Claude Desktop / Cowork MCP at the launcher
+
+Update:
+
+```text
+~/Library/Application Support/Claude/claude_desktop_config.json
+```
+
+Desired entry:
+
+```json
+{
+  "mcpServers": {
+    "sidecar": {
+      "command": "/Users/<you>/.local/bin/sidecar",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+## 6. Point the global Claude skill at the local repo
+
+Replace the global skill copy with a symlink:
+
+```bash
+mkdir -p "$HOME/.claude/skills"
+rm -rf "$HOME/.claude/skills/sidecar"
+ln -s "$SIDECAR_REPO/skill" "$HOME/.claude/skills/sidecar"
+```
+
+This keeps the skill in sync with the checked-out branch automatically.
+
+## 7. For repos with local `.claude/skills`, add a local symlink too
+
+Some repos keep project-local Claude skills. In those repos, global skills may not be enough.
+
+Example:
+
+```bash
+ln -s "$SIDECAR_REPO/skill" "/path/to/project/.claude/skills/sidecar"
+```
+
+If that repo uses git worktrees and each worktree has its own `.claude/skills`, add the same symlink there too.
+
+## 8. Optional: make repo wrappers prefer the local checkout explicitly
+
+If a project has a helper script that runs `sidecar`, prefer:
+
+```bash
+/opt/homebrew/bin/node "$SIDECAR_REPO/bin/sidecar.js"
+```
+
+instead of relying only on `sidecar` being on `PATH`.
+
+This avoids shell-path ambiguity in non-interactive environments.
+
+## 9. Restart Claude
+
+Fully restart:
+
+- Claude Code
+- Claude Desktop / Cowork
+
+They need a restart to pick up the updated MCP config and skill symlinks.
+
+## 10. Verification checklist
+
+Run these:
+
+```bash
+zsh -ic 'command -v sidecar'
+zsh -ic 'sidecar --version'
+cat "$HOME/.claude.json"
+cat "$HOME/Library/Application Support/Claude/claude_desktop_config.json"
+ls -la "$HOME/.claude/skills/sidecar"
+```
+
+Confirm:
+
+- `sidecar` resolves to `~/.local/bin/sidecar`
+- both Claude config files point at `~/.local/bin/sidecar`
+- `~/.claude/skills/sidecar` is a symlink to `<local-sidecar-repo>/skill`
+- any repo-local `.claude/skills/sidecar` entries also point to the same local repo
+
+## Current machine reference
+
+On Will's current machine, the source of truth is:
+
+```text
+/Users/willblanchard/Documents/GitHub/sidecar
+```
+
+The launcher path is:
+
+```text
+/Users/willblanchard/.local/bin/sidecar
+```
+
+The MCP command in both Claude configs is:
+
+```json
+{
+  "command": "/Users/willblanchard/.local/bin/sidecar",
+  "args": ["mcp"]
+}
+```

--- a/docs/research/2026-03-16-openai-codex-auth.md
+++ b/docs/research/2026-03-16-openai-codex-auth.md
@@ -1,0 +1,85 @@
+# Research: OpenAI Codex Auth Reuse And Sidecar Implications
+
+_Migrated into the Sidecar repo from workspace research originally prepared while evaluating Sidecar improvements in another workspace._
+
+## Why This Research Exists
+
+This note captures research that informed the boundaries of Codex-facing Sidecar ideas, especially around whether Sidecar should ever try to unlock OpenAI models by reusing subscription-backed Codex or ChatGPT authentication.
+
+## Short Answer
+
+The safest direction for Sidecar is still:
+
+- direct OpenAI API billing when we want general OpenAI model access
+- official Codex clients and officially documented surfaces when we want subscription-backed Codex access
+
+What this research did **not** establish is a clear official blessing for arbitrary third-party reuse of subscription-backed Codex OAuth as a generic model gateway.
+
+## Key Findings
+
+### 1. ChatGPT Billing And API Billing Are Separate
+
+The research found strong OpenAI documentation that ChatGPT subscriptions and API billing are separate product surfaces. A ChatGPT subscription should not be treated as general-purpose API access.
+
+Implication for Sidecar:
+
+- do not design features around the assumption that a ChatGPT or Codex subscription can substitute for normal API billing in arbitrary third-party flows
+
+### 2. Official Codex Clients Can Authenticate With ChatGPT
+
+The research found documentation showing that official Codex clients can authenticate with ChatGPT on eligible plans.
+
+Implication for Sidecar:
+
+- it is reasonable to treat official Codex surfaces as a supported subscription-backed path
+- it is not reasonable to assume that the same support automatically extends to any external tool that reuses those credentials
+
+### 3. OpenClaw Documents A Real OAuth Pattern
+
+The research found that OpenClaw documents a PKCE OAuth flow for OpenAI Codex and distinguishes subscription-backed Codex usage from direct API-key usage.
+
+Implication for Sidecar:
+
+- the idea is technically plausible
+- technical plausibility is not the same as policy clarity or official support
+
+### 4. Policy Risk Remains Material
+
+The research surfaced terms and help-center language that make unsupported token extraction, credential reuse, or other forms of auth repurposing riskier, especially when they could be interpreted as circumvention.
+
+Implication for Sidecar:
+
+- we should avoid features that import local auth files, scrape tokens, or stretch subscription-backed auth into a general unofficial provider path
+
+## Product Guidance For Sidecar
+
+This research points to a conservative product stance:
+
+- keep direct API-key support as the default way to access OpenAI models
+- keep official-client orchestration safer than token-import schemes
+- avoid building features that depend on `~/.codex/auth.json`, local token copying, or reverse-engineered auth reuse
+- treat any future subscription-backed integration as blocked on clearer official support
+
+## Confidence Notes
+
+- High confidence: ChatGPT billing and API billing are separate.
+- High confidence: official Codex clients can authenticate with ChatGPT on eligible plans.
+- Medium confidence: third-party reuse of subscription-backed OAuth may be technically possible.
+- Medium confidence: public OpenAI docs reviewed in the original research did not clearly bless that third-party reuse pattern.
+
+## Primary Sources Preserved From The Original Research
+
+- https://developers.openai.com/codex/cli
+- https://help.openai.com/en/articles/11369540-using-codex-with-your-chatgpt-plan
+- https://help.openai.com/en/articles/8156019-how-can-i-move-my-chatgpt-subscription-to-the-api
+- https://help.openai.com/en/articles/9039756-billing-settings-in-chatgpt-vs-platform
+- https://docs.openclaw.ai/providers/openai
+- https://docs.openclaw.ai/concepts/oauth
+- https://docs.openclaw.ai/help/faq
+- https://openai.com/policies/terms-of-use/
+- https://help.openai.com/en/articles/10471989
+- https://help.openai.com/en/articles/10562188
+
+## Maintainer Note
+
+This document is a preserved research artifact, not a substitute for fresh policy review. If Sidecar ever revisits subscription-backed OpenAI or Codex auth, re-verify every source against the current official documentation first.

--- a/docs/superpowers/specs/2026-03-16-codex-subagent-design.md
+++ b/docs/superpowers/specs/2026-03-16-codex-subagent-design.md
@@ -89,8 +89,24 @@ The parent-facing contract should stay aligned with current OpenCode subagent co
 
 Initial mapping:
 
+- `Plan` -> `codex exec --json --sandbox read-only`
 - `Explore` -> `codex exec --json --sandbox read-only`
+- `Build` -> `codex exec --json --sandbox workspace-write`
 - `General` -> `codex exec --json --sandbox workspace-write`
+- `Chat` -> not supported for the Codex backend
+
+Because Codex `exec` is non-interactive, Sidecar should reject `chat` for Codex-backed subagents rather than pretending it can match OpenCode's interactive permission-asking behavior.
+
+### Role Prompt Adders
+
+Sandboxing alone is not enough to preserve OpenCode-style role semantics. Sidecar should prepend a short role-specific instruction block to the user briefing for each supported Codex role:
+
+- `plan`: analyze, propose, and do not modify files
+- `explore`: inspect, summarize findings, and stay read-only
+- `build`: make changes directly and report what changed
+- `general`: execute the task with full workspace access and summarize outcomes
+
+These adders should be short and explicit, so Codex gets clear behavioral guidance without drowning out the user briefing.
 
 Additional command behavior for v1:
 
@@ -159,12 +175,14 @@ This keeps the file compatible with existing Sidecar subagent listings while giv
 
 The first implementation slice should verify:
 
-1. `Explore` maps to read-only Codex sandboxing.
-2. `General` maps to writable Codex sandboxing.
-3. A Codex subagent creates the expected session files under the parent Sidecar task.
-4. Streaming execution produces meaningful normalized Sidecar conversation or progress updates before completion.
-5. Final summary output is saved to `summary.md` and final status is correct.
-6. Abort behavior terminates the subprocess and leaves a sane final metadata state.
+1. `Plan` and `Explore` map to read-only Codex sandboxing.
+2. `Build` and `General` map to writable Codex sandboxing.
+3. Role-specific prompt adders are applied for all four supported Codex roles.
+4. `Chat` is rejected clearly as unsupported for Codex-backed subagents.
+5. A Codex subagent creates the expected session files under the parent Sidecar task.
+6. Streaming execution produces meaningful normalized Sidecar conversation or progress updates before completion.
+7. Final summary output is saved to `summary.md` and final status is correct.
+8. Abort behavior terminates the subprocess and leaves a sane final metadata state.
 
 Manual local verification is acceptable for the first slice as long as the implementation also adds unit coverage around process launching, event normalization, and status transitions.
 
@@ -189,7 +207,7 @@ The repo also contains some subagent-oriented documentation and helper APIs, inc
 Proceed with a narrow event-stream adapter:
 
 1. implement `CodexSubagentRunner` around `codex exec --json`
-2. map `Explore` and `General` to Codex sandbox modes
+2. map `Plan`, `Explore`, `Build`, and `General` to Codex sandbox modes and short role prompt adders
 3. persist normalized Sidecar records under the existing subagent session layout
 4. keep docs and product claims intentionally minimal until the local workflow proves valuable
 

--- a/docs/superpowers/specs/2026-03-16-codex-subagent-design.md
+++ b/docs/superpowers/specs/2026-03-16-codex-subagent-design.md
@@ -1,0 +1,196 @@
+# Codex CLI Subagent Backend
+
+**Date:** 2026-03-16
+**Status:** Draft
+
+## Problem
+
+Sidecar has lightweight subagent concepts and storage, but it does not yet have a Sidecar-owned external subagent backend that feels close to OpenCode's native subagent flow.
+
+The current goal is not to make Codex a Sidecar host. The goal is to let Claude Code and Cowork launched Sidecars spawn Codex as a downstream non-interactive worker using the local `codex` CLI, while preserving Sidecar's existing subagent patterns as closely as possible.
+
+For the first slice, this should stay intentionally local and skunk-works:
+
+- rely on a locally working `codex` CLI
+- avoid auth translation or token reuse
+- normalize Codex output into Sidecar records
+- postpone broader docs and product claims until the workflow proves useful
+
+## Goals
+
+- Make Codex feel like another Sidecar subagent backend, not a special one-off command.
+- Preserve the current OpenCode-style subagent patterns across invocation, lifecycle, output, and permissions.
+- Use the non-interactive `codex exec` surface, not interactive Codex sessions.
+- Persist Codex subagents under the existing Sidecar subagent session layout.
+- Capture enough streaming state to support progress visibility and debugging without exposing raw Codex JSON everywhere.
+
+## Non-Goals
+
+- Making Codex a first-class Sidecar host.
+- Reusing ChatGPT or Codex subscription auth through copied tokens or local auth file import.
+- Perfect feature parity with OpenCode child sessions on day one.
+- Resume, fork, or session-history parity unless Codex session identifiers prove easy to map cleanly later.
+- Storing raw Codex JSONL as a first-class artifact in v1.
+
+## Recommended Approach
+
+Build a small Codex subagent backend around `codex exec --json`.
+
+This backend should:
+
+1. create a subagent session directory under the parent Sidecar task
+2. compose a Codex task briefing from the parent Sidecar context
+3. spawn `codex exec` as a subprocess in the project directory
+4. translate streamed Codex JSONL events into Sidecar conversation and progress records
+5. save a normalized final summary into the subagent session
+6. mark the subagent with Sidecar-style final status metadata
+
+This is preferred over a final-output-only shim because the event stream gives us a path to preserve lifecycle and progress patterns that already matter for OpenCode-backed Sidecar runs.
+
+## Architecture
+
+### Backend Boundary
+
+Add a small runner boundary so Sidecar can support multiple subagent backends with similar semantics:
+
+- `OpenCodeSubagentRunner`
+- `CodexSubagentRunner`
+
+The initial implementation only needs to introduce the Codex runner and a thin selection layer where Sidecar decides which backend to use for a subagent.
+
+### Session Shape
+
+Codex subagents should reuse the existing directory pattern:
+
+`.claude/sidecar_sessions/<parentTaskId>/subagents/<subagentId>/`
+
+With the same core files:
+
+- `metadata.json`
+- `conversation.jsonl`
+- `summary.md`
+
+V1 may also write stderr to a backend-specific debug file for diagnosis, but should not expose raw Codex JSONL as the primary record.
+
+### Prompting Model
+
+The parent Sidecar should explicitly build the Codex task briefing. We should not try to infer Claude Code or Cowork conversation state from Codex, and we should not pretend Codex has native access to parent-host context.
+
+The briefing should preserve the same high-level subagent semantics as OpenCode:
+
+- clear task statement
+- project context
+- constraints
+- expected deliverable
+
+## Invocation And Permission Mapping
+
+The parent-facing contract should stay aligned with current OpenCode subagent concepts.
+
+Initial mapping:
+
+- `Explore` -> `codex exec --json --sandbox read-only`
+- `General` -> `codex exec --json --sandbox workspace-write`
+
+Additional command behavior for v1:
+
+- run in the project cwd
+- pass prompt by stdin or argument, whichever is more robust for multiline briefings
+- let Codex use its configured default model unless Sidecar explicitly overrides it later
+- rely on the user's existing Codex CLI login/config instead of building any auth bridge
+
+This preserves permission shape without claiming that Codex and OpenCode are identical under the hood.
+
+## Lifecycle Design
+
+Codex subagents should follow Sidecar's existing status model as closely as possible:
+
+- `running` when the subprocess starts and the subagent session is created
+- `complete` when Codex returns a usable final answer and exits successfully
+- `error` when the subprocess exits non-zero, required output is missing, or event parsing fails
+- `aborted` when Sidecar explicitly terminates the Codex subprocess
+
+The parent session should be able to observe incremental progress while the subprocess runs.
+
+One current compatibility wrinkle is that persisted status handling is not fully unified across the codebase today. Some modules and docs already refer to statuses like `aborted` and `crashed`, while `src/session-manager.js` still centers a smaller constant set. The Codex backend should align with the statuses Sidecar actually wants to expose, and this work may need to tighten that status model instead of assuming it is already canonical.
+
+## Event Normalization
+
+Use `codex exec --json` and translate the minimum useful event set into backend-agnostic Sidecar records.
+
+V1 normalization priorities:
+
+- assistant text deltas or messages -> append normalized assistant content to `conversation.jsonl`
+- tool invocation style events -> record as Sidecar tool-use style entries when possible
+- progress/status events -> update Sidecar progress state
+- final message/result event -> derive `summary.md`
+
+The important design choice is normalization, not raw event exposure. Sidecar readers and future UI should consume a stable internal model even if the Codex event schema evolves.
+
+If event coverage is incomplete at first, correctness of final status and final summary matters more than perfect fidelity for every intermediate event.
+
+Another current wrinkle is that Sidecar's progress labels are still OpenCode-oriented in places. The Codex backend should either reuse only backend-agnostic progress stages or extend the progress model so Codex-specific execution does not look misleadingly like OpenCode server startup.
+
+## Metadata Additions
+
+`metadata.json` for Codex subagents should include enough backend detail for diagnosis:
+
+- `backend: "codex"`
+- `agentType`
+- `pid`
+- `status`
+- `createdAt`
+- `completedAt`
+- `exitCode`
+- `sandboxMode`
+- optional error fields such as `reason`
+
+This keeps the file compatible with existing Sidecar subagent listings while giving us enough backend-specific debugging detail.
+
+## Error Handling
+
+- Fail fast if `codex` is not installed or `codex exec --help` cannot run.
+- Capture stderr to a file so auth, config, or sandbox failures are inspectable.
+- Treat malformed JSONL as a backend error, but preserve enough raw context to debug the failure.
+- If Codex emits a useful final message but exits unexpectedly, record that clearly in metadata instead of silently dropping the result.
+- Ensure abort logic kills the Codex subprocess and updates subagent status consistently.
+
+## Verification
+
+The first implementation slice should verify:
+
+1. `Explore` maps to read-only Codex sandboxing.
+2. `General` maps to writable Codex sandboxing.
+3. A Codex subagent creates the expected session files under the parent Sidecar task.
+4. Streaming execution produces meaningful normalized Sidecar conversation or progress updates before completion.
+5. Final summary output is saved to `summary.md` and final status is correct.
+6. Abort behavior terminates the subprocess and leaves a sane final metadata state.
+
+Manual local verification is acceptable for the first slice as long as the implementation also adds unit coverage around process launching, event normalization, and status transitions.
+
+## Implementation Notes
+
+The current codebase already provides useful building blocks:
+
+- subagent session storage helpers in `src/session-manager.js`
+- headless conversation and tool-call logging patterns in `src/headless.js`
+- subprocess-oriented lifecycle patterns elsewhere in Sidecar's CLI and MCP flows
+
+The repo also contains some subagent-oriented documentation and helper APIs, including OpenCode child-session helpers. What is not yet clearly wired in the current runtime code is a complete Sidecar-owned subagent orchestration path that persists, monitors, and finalizes external subagents end to end. This work should therefore be treated as the first explicit external subagent backend, not as a minor extension of a mature existing system.
+
+## Open Questions
+
+- Where should backend selection live so Codex subagents can be introduced without over-abstracting too early?
+- Which Codex JSON event types are sufficient for a useful v1 normalization layer?
+- Do we want to store a raw event trace later behind a debug flag if normalized records prove insufficient?
+
+## Recommendation
+
+Proceed with a narrow event-stream adapter:
+
+1. implement `CodexSubagentRunner` around `codex exec --json`
+2. map `Explore` and `General` to Codex sandbox modes
+3. persist normalized Sidecar records under the existing subagent session layout
+4. keep docs and product claims intentionally minimal until the local workflow proves valuable
+
+This gives Sidecar a real external subagent backend while staying close to OpenCode-style subagent behavior and avoiding premature productization.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -24,7 +24,7 @@ sidecar update                       # Update to latest version
 claude mcp add-json sidecar '{"command":"npx","args":["-y","claude-sidecar@latest","mcp"]}' --scope user
 ```
 
-MCP tools: `sidecar_start`, `sidecar_status`, `sidecar_read`, `sidecar_list`, `sidecar_resume`, `sidecar_continue`, `sidecar_setup`, `sidecar_guide`, `sidecar_abort`
+MCP tools: `sidecar_start`, `sidecar_status`, `sidecar_read`, `sidecar_list`, `sidecar_resume`, `sidecar_continue`, `sidecar_setup`, `sidecar_guide`, `sidecar_abort`, `sidecar_subagent_start`, `sidecar_subagent_status`, `sidecar_subagent_read`, `sidecar_subagent_abort`
 
 Session statuses: `running`, `complete`, `aborted`, `crashed`, `error`
 
@@ -40,6 +40,23 @@ The `--agent` option specifies which OpenCode native agent to use:
 | **Explore** | Read-only subagent | Read-only |
 
 Custom agents defined in `~/.config/opencode/agents/` or `.opencode/agents/` are also supported.
+
+## Codex Subagents (Experimental / Local)
+
+Sidecar can start Codex-backed subagents beneath an existing parent Sidecar task through the MCP tools:
+
+- `sidecar_subagent_start`
+- `sidecar_subagent_status`
+- `sidecar_subagent_read`
+- `sidecar_subagent_abort`
+
+Current constraints:
+
+- Supported Codex subagent roles: `plan`, `explore`, `build`, `general`
+- `chat` is intentionally unsupported because Codex `exec` is non-interactive
+- `plan` and `explore` run with Codex `read-only` sandboxing
+- `build` and `general` run with Codex `workspace-write` sandboxing
+- Output is stored under the parent task at `.claude/sidecar_sessions/<parentTaskId>/subagents/<subagentId>/`
 
 ## Process Self-Termination
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   testPathIgnorePatterns: [
     '/node_modules/',
     '\\.integration\\.test\\.js$',
-    '\\.worktrees/'
+    '<rootDir>/\\.worktrees/'
   ],
   collectCoverageFrom: [
     'src/**/*.js',

--- a/src/cli-handlers.js
+++ b/src/cli-handlers.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /**
  * CLI Command Handlers
  *
@@ -5,9 +6,12 @@
  * under the 300-line limit.
  */
 
-const fs = require('fs');
-const path = require('path');
-const { validateTaskId, safeSessionDir } = require('./utils/validators');
+const { validateTaskId } = require('./utils/validators');
+const {
+  readContainedSessionFile,
+  validateSidecarSessionDir,
+  writeContainedSessionFile,
+} = require('./utils/sidecar-boundaries');
 
 /**
  * Handle 'sidecar setup' command
@@ -69,24 +73,37 @@ async function handleAbort(args) {
   }
 
   const project = args.cwd || process.cwd();
-  const sessionDir = safeSessionDir(project, taskId);
-  const metaPath = path.join(sessionDir, 'metadata.json');
+  let sessionDir;
+  let metadataText;
 
-  if (!fs.existsSync(metaPath)) {
+  try {
+    sessionDir = validateSidecarSessionDir(project, taskId);
+    metadataText = readContainedSessionFile(sessionDir, 'metadata.json', { optional: true });
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+
+  if (metadataText === null) {
     console.error(`Session ${taskId} not found`);
     process.exit(1);
   }
 
   let meta;
   try {
-    meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+    meta = JSON.parse(metadataText);
   } catch (_err) {
     console.error(`Session ${taskId} has malformed metadata`);
     process.exit(1);
   }
   meta.status = 'aborted';
   meta.abortedAt = new Date().toISOString();
-  fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), { mode: 0o600 });
+  try {
+    writeContainedSessionFile(sessionDir, 'metadata.json', JSON.stringify(meta, null, 2), { mode: 0o600 });
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
   console.log(`Session ${taskId} marked as aborted.`);
 }
 
@@ -105,7 +122,7 @@ async function handleUpdate() {
   }
   const result = await performUpdate();
   if (result.success) {
-    console.log(`Updated successfully! Run 'sidecar --version' to verify.`);
+    console.log('Updated successfully! Run \'sidecar --version\' to verify.');
   } else {
     console.error(`Update failed: ${result.error}`);
     process.exit(1);

--- a/src/cli.js
+++ b/src/cli.js
@@ -101,6 +101,7 @@ function isBooleanFlag(key) {
      'no-ui',
      'no-mcp',
      'no-context',
+     'include-context',
      'setup',
      'all',
      // 'summary', // summary is now an option with a value
@@ -311,10 +312,11 @@ Options for 'start':
   --session-id <id|"current">  Session ID to pull context from (default: current)
   --cwd <path>                 Project directory (default: cwd)
   --no-ui                      Run without GUI (autonomous mode)
+  --include-context              Include parent conversation history context
   --no-context                   Skip parent conversation history context
   --timeout <minutes>          Headless timeout (default: 15)
   --client <type>              Client type: code-local, code-web, cowork
-  --session-dir <path>         Explicit session data directory
+  --session-dir <path>         Explicit session data directory under project
   --setup                      Force open configuration
   --fold-shortcut <key>        Customize fold shortcut
   --opencode-port <port>       Port override for OpenCode server

--- a/src/headless.js
+++ b/src/headless.js
@@ -12,6 +12,10 @@ const { ensureNodeModulesBinInPath } = require('./utils/path-setup');
 const { ensurePortAvailable } = require('./utils/server-setup');
 const { mapAgentToOpenCode } = require('./utils/agent-mapping');
 const { writeProgress } = require('./sidecar/progress');
+const {
+  appendContainedSessionFile,
+  ensureSidecarSessionDir
+} = require('./utils/sidecar-session-boundaries');
 
 /**
  * Fold marker that the agent outputs when done
@@ -72,13 +76,8 @@ async function runHeadless(model, systemPrompt, userMessage, taskId, project, ti
   } = require('./opencode-client');
 
   const { reasoning } = options;
-  const sessionDir = path.join(project, '.claude', 'sidecar_sessions', taskId);
+  const sessionDir = ensureSidecarSessionDir(project, taskId);
   const conversationPath = path.join(sessionDir, 'conversation.jsonl');
-
-  // Ensure session directory exists
-  if (!fs.existsSync(sessionDir)) {
-    fs.mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
-  }
 
   // Log system prompt as first message in conversation
   logMessage(conversationPath, {
@@ -606,7 +605,12 @@ function formatFoldOutput({ model, sessionId, client, cwd, mode, summary }) {
  * @param {object} message - Message object with role, content, timestamp
  */
 function logMessage(conversationPath, message) {
-  fs.appendFileSync(conversationPath, JSON.stringify(message) + '\n', { mode: 0o600 });
+  appendContainedSessionFile(
+    path.dirname(conversationPath),
+    path.basename(conversationPath),
+    JSON.stringify(message) + '\n',
+    { mode: 0o600 }
+  );
 }
 
 module.exports = {

--- a/src/headless.js
+++ b/src/headless.js
@@ -5,7 +5,6 @@
  * Uses OpenCode SDK for headless execution (no CLI spawning required).
  */
 
-const fs = require('fs');
 const path = require('path');
 const { logger } = require('./utils/logger');
 const { ensureNodeModulesBinInPath } = require('./utils/path-setup');
@@ -14,7 +13,8 @@ const { mapAgentToOpenCode } = require('./utils/agent-mapping');
 const { writeProgress } = require('./sidecar/progress');
 const {
   appendContainedSessionFile,
-  ensureSidecarSessionDir
+  ensureSidecarSessionDir,
+  readContainedSessionFile
 } = require('./utils/sidecar-session-boundaries');
 
 /**
@@ -260,9 +260,8 @@ async function runHeadless(model, systemPrompt, userMessage, taskId, project, ti
 
       // Check for external abort signal (MCP tool or CLI command)
       try {
-        const metaCheck = path.join(sessionDir, 'metadata.json');
-        if (fs.existsSync(metaCheck)) {
-          const metaContent = fs.readFileSync(metaCheck, 'utf-8');
+        const metaContent = readContainedSessionFile(sessionDir, 'metadata.json', { optional: true });
+        if (metaContent !== null) {
           const meta = JSON.parse(metaContent);
           if (meta.status === 'aborted') {
             logger.info('External abort signal received', { taskId });

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -4,9 +4,13 @@ const path = require('path');
 const { spawn } = require('child_process');
 const { getTools, getGuideText } = require('./mcp-tools');
 const { tryResolveModel } = require('./utils/config');
-const os = require('os');
 const { logger } = require('./utils/logger');
 const { safeSessionDir } = require('./utils/validators');
+const {
+  assertContextBinding,
+  validateProjectPath,
+  validateSubagentParent
+} = require('./utils/sidecar-boundaries');
 const { readProgress } = require('./sidecar/progress');
 const { SharedServerManager } = require('./utils/shared-server');
 
@@ -14,11 +18,20 @@ const sharedServer = new SharedServerManager({ logger });
 
 /** Resolve the project directory with smart fallback. */
 function getProjectDir(explicitProject) {
-  if (explicitProject && fs.existsSync(explicitProject)) { return explicitProject; }
   const cwd = process.cwd();
-  if (cwd !== '/' && fs.existsSync(cwd)) { return cwd; }
-  if (cwd === '/') { logger.warn('cwd is root (/), falling back to $HOME'); }
-  return os.homedir();
+  if (explicitProject && fs.existsSync(explicitProject)) {
+    return validateProjectPath(path.resolve(explicitProject), { cwd });
+  }
+  return validateProjectPath(path.resolve(cwd), { cwd });
+}
+
+/** Resolve and validate the project path used by an MCP handler. */
+function resolveHandlerProject(input = {}, project) {
+  if (project) {
+    const resolved = path.resolve(project);
+    return validateProjectPath(resolved, { cwd: resolved, allowedRoots: [resolved] });
+  }
+  return getProjectDir(input.project);
 }
 
 /** Read session metadata from disk, or null if not found */
@@ -27,6 +40,18 @@ function readMetadata(taskId, project) {
   const metaPath = path.join(sessionDir, 'metadata.json');
   if (!fs.existsSync(metaPath)) { return null; }
   return JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+}
+
+/** Read and validate parent metadata before using subagent files. */
+function readValidatedParentMetadata(taskId, project) {
+  const metadata = readMetadata(taskId, project);
+  if (!metadata) { return null; }
+  validateSubagentParent({
+    ...metadata,
+    taskId: metadata.taskId || taskId,
+    projectDir: metadata.projectDir || metadata.project || project
+  }, project);
+  return metadata;
 }
 
 /** Resolve a subagent session directory safely beneath a parent sidecar task. */
@@ -97,9 +122,22 @@ const handlers = {
     }
     const resolvedModel = validation.resolvedModel;
 
-    const cwd = project || getProjectDir(input.project);
+    const cwd = resolveHandlerProject(input, project);
     const { generateTaskId } = require('./sidecar/start');
     const taskId = generateTaskId();
+    const includeContext = input.includeContext === true;
+    if (includeContext) {
+      try {
+        assertContextBinding({
+          parentSession: input.parentSession,
+          session: input.parentSession,
+          coworkProcess: input.coworkProcess,
+          client: input.coworkProcess ? 'cowork' : undefined
+        });
+      } catch (err) {
+        return textResult(err.message, true);
+      }
+    }
 
     const args = ['start', '--prompt', input.prompt, '--task-id', taskId, '--client', 'cowork'];
     if (resolvedModel) { args.push('--model', resolvedModel); }
@@ -113,7 +151,7 @@ const handlers = {
     if (input.contextSince)     { args.push('--context-since', input.contextSince); }
     if (input.contextMaxTokens) { args.push('--context-max-tokens', String(input.contextMaxTokens)); }
     if (input.summaryLength)    { args.push('--summary-length', input.summaryLength); }
-    if (input.includeContext === false) { args.push('--no-context'); }
+    if (!includeContext) { args.push('--no-context'); }
     if (input.coworkProcess)    { args.push('--cowork-process', input.coworkProcess); }
     if (input.parentSession)    { args.push('--session-id', input.parentSession); }
     if (input.windowPosition)   { args.push('--position', input.windowPosition); }
@@ -145,22 +183,26 @@ const handlers = {
           opencodeSessionId: sessionId,
           opencodePort: serverPort,
           goPid: server.goPid || null,
+          project: cwd,
+          projectDir: cwd,
           createdAt: new Date().toISOString(),
           headless: true, model: resolvedModel,
         }, null, 2), { mode: 0o600 });
 
         // Build context from parent conversation (unless --no-context)
         let context = null;
-        if (input.includeContext !== false) {
+        if (includeContext) {
           try {
             context = buildContext(cwd, input.parentSession, {
               contextTurns: input.contextTurns,
               contextSince: input.contextSince,
               contextMaxTokens: input.contextMaxTokens,
               coworkProcess: input.coworkProcess,
+              client: input.coworkProcess ? 'cowork' : undefined,
+              parentProject: cwd,
             });
           } catch (ctxErr) {
-            logger.warn('Failed to build context, proceeding without', { error: ctxErr.message });
+            return textResult(`Failed to build context: ${ctxErr.message}`, true);
           }
         }
 
@@ -241,6 +283,7 @@ const handlers = {
       if (!fs.existsSync(metaPath)) {
         fs.writeFileSync(metaPath, JSON.stringify({
           taskId, status: 'running', pid: child.pid, createdAt: new Date().toISOString(),
+          project: cwd, projectDir: cwd,
           headless: !!input.noUi,
         }, null, 2), { mode: 0o600 });
       }
@@ -262,7 +305,7 @@ const handlers = {
   },
 
   async sidecar_status(input, project) {
-    const cwd = project || getProjectDir(input.project);
+    const cwd = resolveHandlerProject(input, project);
     const sessionDir = safeSessionDir(cwd, input.taskId);
     const metadata = readMetadata(input.taskId, cwd);
     if (!metadata) { return textResult(`Session ${input.taskId} not found.`, true); }
@@ -314,7 +357,7 @@ const handlers = {
   },
 
   async sidecar_read(input, project) {
-    const cwd = project || getProjectDir(input.project);
+    const cwd = resolveHandlerProject(input, project);
     const sessionDir = safeSessionDir(cwd, input.taskId);
     if (!fs.existsSync(sessionDir)) {
       return textResult(`Session ${input.taskId} not found.`, true);
@@ -344,7 +387,7 @@ const handlers = {
   },
 
   async sidecar_list(input, project) {
-    const cwd = project || getProjectDir(input.project);
+    const cwd = resolveHandlerProject(input, project);
     const sessionsDir = path.join(cwd, '.claude', 'sidecar_sessions');
     if (!fs.existsSync(sessionsDir)) { return textResult('No sidecar sessions found.'); }
 
@@ -375,7 +418,7 @@ const handlers = {
   },
 
   async sidecar_resume(input, project) {
-    const cwd = project || getProjectDir(input.project);
+    const cwd = resolveHandlerProject(input, project);
     const sessionDir = safeSessionDir(cwd, input.taskId);
     const args = ['resume', input.taskId, '--client', 'cowork', '--cwd', cwd];
     if (input.noUi) { args.push('--no-ui', '--agent', 'build'); }
@@ -397,7 +440,7 @@ const handlers = {
       }
     }
 
-    const cwd = project || getProjectDir(input.project);
+    const cwd = resolveHandlerProject(input, project);
     const { generateTaskId } = require('./sidecar/start');
     const newTaskId = generateTaskId();
     const sessionDir = path.join(cwd, '.claude', 'sidecar_sessions', newTaskId);
@@ -419,7 +462,7 @@ const handlers = {
   },
 
   async sidecar_abort(input, project) {
-    const cwd = project || getProjectDir(input.project);
+    const cwd = resolveHandlerProject(input, project);
     const metadata = readMetadata(input.taskId, cwd);
     if (!metadata) { return textResult(`Session ${input.taskId} not found.`, true); }
     if (metadata.status !== 'running') {
@@ -446,8 +489,8 @@ const handlers = {
   },
 
   async sidecar_subagent_start(input, project) {
-    const cwd = project || getProjectDir(input.project);
-    const parentMetadata = readMetadata(input.parentTaskId, cwd);
+    const cwd = resolveHandlerProject(input, project);
+    const parentMetadata = readValidatedParentMetadata(input.parentTaskId, cwd);
     if (!parentMetadata) {
       return textResult(`Parent session ${input.parentTaskId} not found.`, true);
     }
@@ -483,7 +526,11 @@ const handlers = {
   },
 
   async sidecar_subagent_status(input, project) {
-    const cwd = project || getProjectDir(input.project);
+    const cwd = resolveHandlerProject(input, project);
+    const parentMetadata = readValidatedParentMetadata(input.parentTaskId, cwd);
+    if (!parentMetadata) {
+      return textResult(`Parent session ${input.parentTaskId} not found.`, true);
+    }
     const subagentDir = getSubagentSessionDir(cwd, input.parentTaskId, input.subagentId);
     const metadata = readSubagentMetadata(cwd, input.parentTaskId, input.subagentId);
     if (!metadata) {
@@ -524,7 +571,11 @@ const handlers = {
   },
 
   async sidecar_subagent_read(input, project) {
-    const cwd = project || getProjectDir(input.project);
+    const cwd = resolveHandlerProject(input, project);
+    const parentMetadata = readValidatedParentMetadata(input.parentTaskId, cwd);
+    if (!parentMetadata) {
+      return textResult(`Parent session ${input.parentTaskId} not found.`, true);
+    }
     const subagentDir = getSubagentSessionDir(cwd, input.parentTaskId, input.subagentId);
     if (!fs.existsSync(subagentDir)) {
       return textResult(`Sub-agent ${input.subagentId} not found under parent ${input.parentTaskId}.`, true);
@@ -548,7 +599,11 @@ const handlers = {
   },
 
   async sidecar_subagent_abort(input, project) {
-    const cwd = project || getProjectDir(input.project);
+    const cwd = resolveHandlerProject(input, project);
+    const parentMetadata = readValidatedParentMetadata(input.parentTaskId, cwd);
+    if (!parentMetadata) {
+      return textResult(`Parent session ${input.parentTaskId} not found.`, true);
+    }
     const metadata = readSubagentMetadata(cwd, input.parentTaskId, input.subagentId);
     if (!metadata) {
       return textResult(`Sub-agent ${input.subagentId} not found under parent ${input.parentTaskId}.`, true);

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -200,6 +200,7 @@ const handlers = {
               coworkProcess: input.coworkProcess,
               client: input.coworkProcess ? 'cowork' : undefined,
               parentProject: cwd,
+              exactSession: true,
             });
           } catch (ctxErr) {
             return textResult(`Failed to build context: ${ctxErr.message}`, true);

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -29,6 +29,20 @@ function readMetadata(taskId, project) {
   return JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
 }
 
+/** Resolve a subagent session directory safely beneath a parent sidecar task. */
+function getSubagentSessionDir(project, parentTaskId, subagentId) {
+  const { getSubagentDir } = require('./session-manager');
+  return getSubagentDir(project, parentTaskId, subagentId);
+}
+
+/** Read subagent metadata from disk, or null if not found. */
+function readSubagentMetadata(project, parentTaskId, subagentId) {
+  const sessionDir = getSubagentSessionDir(project, parentTaskId, subagentId);
+  const metaPath = path.join(sessionDir, 'metadata.json');
+  if (!fs.existsSync(metaPath)) { return null; }
+  return JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+}
+
 /** Build an MCP text response */
 function textResult(text, isError) {
   const result = { content: [{ type: 'text', text }] };
@@ -428,6 +442,147 @@ const handlers = {
     return textResult(JSON.stringify({
       taskId: input.taskId, status: 'aborted',
       message: 'Session abort requested. The sidecar process will terminate shortly.',
+    }));
+  },
+
+  async sidecar_subagent_start(input, project) {
+    const cwd = project || getProjectDir(input.project);
+    const parentMetadata = readMetadata(input.parentTaskId, cwd);
+    if (!parentMetadata) {
+      return textResult(`Parent session ${input.parentTaskId} not found.`, true);
+    }
+
+    const { generateTaskId } = require('./sidecar/start');
+    const { startCodexSubagent } = require('./subagents/codex-runner');
+    const subagentId = generateTaskId();
+    const run = await startCodexSubagent({
+      projectDir: cwd,
+      parentTaskId: input.parentTaskId,
+      subagentId,
+      briefing: input.prompt,
+      agentType: input.agentType,
+      model: input.model,
+    });
+
+    if (run && run.completion && typeof run.completion.catch === 'function') {
+      run.completion.catch((err) => {
+        logger.warn('Codex subagent completion rejected', {
+          parentTaskId: input.parentTaskId,
+          subagentId,
+          error: err.message
+        });
+      });
+    }
+
+    return textResult(JSON.stringify({
+      parentTaskId: input.parentTaskId,
+      subagentId,
+      status: 'running',
+      backend: 'codex',
+    }));
+  },
+
+  async sidecar_subagent_status(input, project) {
+    const cwd = project || getProjectDir(input.project);
+    const subagentDir = getSubagentSessionDir(cwd, input.parentTaskId, input.subagentId);
+    const metadata = readSubagentMetadata(cwd, input.parentTaskId, input.subagentId);
+    if (!metadata) {
+      return textResult(`Sub-agent ${input.subagentId} not found under parent ${input.parentTaskId}.`, true);
+    }
+
+    if (metadata.status === 'running' && metadata.pid) {
+      try { process.kill(metadata.pid, 0); } catch {
+        const { updateSubagentSession } = require('./session-manager');
+        updateSubagentSession(cwd, input.parentTaskId, input.subagentId, {
+          status: 'crashed',
+          reason: 'Process exited unexpectedly',
+          completedAt: new Date().toISOString(),
+          pid: null
+        });
+      }
+    }
+
+    const refreshed = readSubagentMetadata(cwd, input.parentTaskId, input.subagentId);
+    const response = {
+      parentTaskId: input.parentTaskId,
+      subagentId: input.subagentId,
+      status: refreshed.status,
+      backend: refreshed.backend
+    };
+
+    if (refreshed.agentType) {
+      response.agentType = refreshed.agentType;
+    }
+    if (refreshed.status === 'running') {
+      Object.assign(response, readProgress(subagentDir));
+    }
+    if (refreshed.status === 'crashed' || refreshed.status === 'error') {
+      response.reason = refreshed.reason || 'Unknown error';
+    }
+
+    return textResult(JSON.stringify(response));
+  },
+
+  async sidecar_subagent_read(input, project) {
+    const cwd = project || getProjectDir(input.project);
+    const subagentDir = getSubagentSessionDir(cwd, input.parentTaskId, input.subagentId);
+    if (!fs.existsSync(subagentDir)) {
+      return textResult(`Sub-agent ${input.subagentId} not found under parent ${input.parentTaskId}.`, true);
+    }
+
+    const mode = input.mode || 'summary';
+    if (mode === 'metadata') {
+      return textResult(fs.readFileSync(path.join(subagentDir, 'metadata.json'), 'utf-8'));
+    }
+    if (mode === 'conversation') {
+      const convPath = path.join(subagentDir, 'conversation.jsonl');
+      if (!fs.existsSync(convPath)) { return textResult('No conversation recorded.'); }
+      return textResult(fs.readFileSync(convPath, 'utf-8'));
+    }
+
+    const summaryPath = path.join(subagentDir, 'summary.md');
+    if (!fs.existsSync(summaryPath)) {
+      return textResult('No summary available (subagent may still be running).');
+    }
+    return textResult(fs.readFileSync(summaryPath, 'utf-8'));
+  },
+
+  async sidecar_subagent_abort(input, project) {
+    const cwd = project || getProjectDir(input.project);
+    const metadata = readSubagentMetadata(cwd, input.parentTaskId, input.subagentId);
+    if (!metadata) {
+      return textResult(`Sub-agent ${input.subagentId} not found under parent ${input.parentTaskId}.`, true);
+    }
+    if (metadata.status !== 'running') {
+      return textResult(
+        `Sub-agent ${input.subagentId} is not running (status: ${metadata.status}).`
+      );
+    }
+
+    if (metadata.pid) {
+      try { process.kill(metadata.pid, 'SIGTERM'); } catch (err) {
+        if (err.code !== 'ESRCH') {
+          logger.warn('Failed to kill Codex subagent process', {
+            pid: metadata.pid,
+            error: err.message
+          });
+        }
+      }
+    }
+
+    const { updateSubagentSession } = require('./session-manager');
+    updateSubagentSession(cwd, input.parentTaskId, input.subagentId, {
+      status: 'aborted',
+      abortedAt: new Date().toISOString(),
+      pid: null
+    });
+
+    return textResult(JSON.stringify({
+      parentTaskId: input.parentTaskId,
+      subagentId: input.subagentId,
+      status: 'aborted',
+      backend: metadata.backend || 'codex',
+      message: 'Sub-agent abort requested. The Codex process will terminate shortly.',
     }));
   },
 

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -11,7 +11,10 @@ const {
   readContainedSessionFile,
   validateProjectPath,
   validateSidecarSessionDir,
-  validateSubagentParent
+  validateSidecarSessionsRoot,
+  validateSidecarSubagentSessionDir,
+  validateSubagentParent,
+  writeContainedSessionFile,
 } = require('./utils/sidecar-boundaries');
 const { readProgress } = require('./sidecar/progress');
 const { SharedServerManager } = require('./utils/shared-server');
@@ -67,16 +70,15 @@ function readValidatedParentMetadata(taskId, project) {
 
 /** Resolve a subagent session directory safely beneath a parent sidecar task. */
 function getSubagentSessionDir(project, parentTaskId, subagentId) {
-  const { getSubagentDir } = require('./session-manager');
-  return getSubagentDir(project, parentTaskId, subagentId);
+  return validateSidecarSubagentSessionDir(project, parentTaskId, subagentId);
 }
 
 /** Read subagent metadata from disk, or null if not found. */
 function readSubagentMetadata(project, parentTaskId, subagentId) {
   const sessionDir = getSubagentSessionDir(project, parentTaskId, subagentId);
-  const metaPath = path.join(sessionDir, 'metadata.json');
-  if (!fs.existsSync(metaPath)) { return null; }
-  return JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+  const metadataText = readContainedSessionFile(sessionDir, 'metadata.json', { optional: true });
+  if (metadataText === null) { return null; }
+  return JSON.parse(metadataText);
 }
 
 /** Build an MCP text response */
@@ -338,8 +340,8 @@ const handlers = {
           status: 'crashed', crashedAt: new Date().toISOString(),
           reason: 'Process exited unexpectedly',
         });
-        fs.writeFileSync(path.join(sessionDir, 'metadata.json'),
-          JSON.stringify(metadata, null, 2));
+        writeContainedSessionFile(sessionDir, 'metadata.json',
+          JSON.stringify(metadata, null, 2), { mode: 0o600 });
       }
     }
 
@@ -416,15 +418,23 @@ const handlers = {
 
   async sidecar_list(input, project) {
     const cwd = resolveHandlerProject(input, project);
-    const sessionsDir = path.join(cwd, '.claude', 'sidecar_sessions');
-    if (!fs.existsSync(sessionsDir)) { return textResult('No sidecar sessions found.'); }
+    let sessionsDir;
+    try {
+      sessionsDir = validateSidecarSessionsRoot(cwd);
+    } catch (err) {
+      if (/does not exist/i.test(err.message)) {
+        return textResult('No sidecar sessions found.');
+      }
+      return textResult(err.message, true);
+    }
 
     let sessions = fs.readdirSync(sessionsDir)
       .filter(d => /^[a-zA-Z0-9_-]{1,64}$/.test(d))
-      .filter(d => fs.existsSync(path.join(sessionsDir, d, 'metadata.json')))
       .map(d => {
         try {
-          const meta = JSON.parse(fs.readFileSync(path.join(sessionsDir, d, 'metadata.json'), 'utf-8'));
+          const sessionDir = validateSidecarSessionDir(cwd, d);
+          const meta = readMetadataFromSessionDir(sessionDir);
+          if (!meta) { return null; }
           return {
             id: d, model: meta.model, status: meta.status, agent: meta.agent,
             briefing: (String(meta.briefing || '')).slice(0, 80),
@@ -516,10 +526,14 @@ const handlers = {
         }
       }
     }
-    const metaPath = path.join(sessionDir, 'metadata.json');
     metadata.status = 'aborted';
     metadata.abortedAt = new Date().toISOString();
-    fs.writeFileSync(metaPath, JSON.stringify(metadata, null, 2));
+    writeContainedSessionFile(
+      sessionDir,
+      'metadata.json',
+      JSON.stringify(metadata, null, 2),
+      { mode: 0o600 }
+    );
 
     return textResult(JSON.stringify({
       taskId: input.taskId, status: 'aborted',
@@ -570,8 +584,14 @@ const handlers = {
     if (!parentMetadata) {
       return textResult(`Parent session ${input.parentTaskId} not found.`, true);
     }
-    const subagentDir = getSubagentSessionDir(cwd, input.parentTaskId, input.subagentId);
-    const metadata = readSubagentMetadata(cwd, input.parentTaskId, input.subagentId);
+    let subagentDir;
+    let metadata;
+    try {
+      subagentDir = getSubagentSessionDir(cwd, input.parentTaskId, input.subagentId);
+      metadata = readSubagentMetadata(cwd, input.parentTaskId, input.subagentId);
+    } catch (err) {
+      return textResult(err.message, true);
+    }
     if (!metadata) {
       return textResult(`Sub-agent ${input.subagentId} not found under parent ${input.parentTaskId}.`, true);
     }
@@ -615,26 +635,40 @@ const handlers = {
     if (!parentMetadata) {
       return textResult(`Parent session ${input.parentTaskId} not found.`, true);
     }
-    const subagentDir = getSubagentSessionDir(cwd, input.parentTaskId, input.subagentId);
-    if (!fs.existsSync(subagentDir)) {
-      return textResult(`Sub-agent ${input.subagentId} not found under parent ${input.parentTaskId}.`, true);
+    let subagentDir;
+    try {
+      subagentDir = getSubagentSessionDir(cwd, input.parentTaskId, input.subagentId);
+    } catch (err) {
+      return textResult(err.message, true);
     }
 
     const mode = input.mode || 'summary';
     if (mode === 'metadata') {
-      return textResult(fs.readFileSync(path.join(subagentDir, 'metadata.json'), 'utf-8'));
+      const metadataText = readContainedSessionFile(subagentDir, 'metadata.json', { optional: true });
+      if (metadataText === null) {
+        return textResult(`Sub-agent ${input.subagentId} not found under parent ${input.parentTaskId}.`, true);
+      }
+      return textResult(metadataText);
     }
     if (mode === 'conversation') {
-      const convPath = path.join(subagentDir, 'conversation.jsonl');
-      if (!fs.existsSync(convPath)) { return textResult('No conversation recorded.'); }
-      return textResult(fs.readFileSync(convPath, 'utf-8'));
+      try {
+        const conversation = readContainedSessionFile(subagentDir, 'conversation.jsonl', { optional: true });
+        if (conversation === null) { return textResult('No conversation recorded.'); }
+        return textResult(conversation);
+      } catch (err) {
+        return textResult(err.message, true);
+      }
     }
 
-    const summaryPath = path.join(subagentDir, 'summary.md');
-    if (!fs.existsSync(summaryPath)) {
-      return textResult('No summary available (subagent may still be running).');
+    try {
+      const summary = readContainedSessionFile(subagentDir, 'summary.md', { optional: true });
+      if (summary === null) {
+        return textResult('No summary available (subagent may still be running).');
+      }
+      return textResult(summary);
+    } catch (err) {
+      return textResult(err.message, true);
     }
-    return textResult(fs.readFileSync(summaryPath, 'utf-8'));
   },
 
   async sidecar_subagent_abort(input, project) {
@@ -643,7 +677,12 @@ const handlers = {
     if (!parentMetadata) {
       return textResult(`Parent session ${input.parentTaskId} not found.`, true);
     }
-    const metadata = readSubagentMetadata(cwd, input.parentTaskId, input.subagentId);
+    let metadata;
+    try {
+      metadata = readSubagentMetadata(cwd, input.parentTaskId, input.subagentId);
+    } catch (err) {
+      return textResult(err.message, true);
+    }
     if (!metadata) {
       return textResult(`Sub-agent ${input.subagentId} not found under parent ${input.parentTaskId}.`, true);
     }

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -48,8 +48,7 @@ function readValidatedParentMetadata(taskId, project) {
   if (!metadata) { return null; }
   validateSubagentParent({
     ...metadata,
-    taskId: metadata.taskId || taskId,
-    projectDir: metadata.projectDir || metadata.project || project
+    taskId: metadata.taskId || taskId
   }, project);
   return metadata;
 }
@@ -151,6 +150,7 @@ const handlers = {
     if (input.contextSince)     { args.push('--context-since', input.contextSince); }
     if (input.contextMaxTokens) { args.push('--context-max-tokens', String(input.contextMaxTokens)); }
     if (input.summaryLength)    { args.push('--summary-length', input.summaryLength); }
+    if (includeContext) { args.push('--include-context'); }
     if (!includeContext) { args.push('--no-context'); }
     if (input.coworkProcess)    { args.push('--cowork-process', input.coworkProcess); }
     if (input.parentSession)    { args.push('--session-id', input.parentSession); }

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -8,6 +8,7 @@ const { logger } = require('./utils/logger');
 const {
   assertContextBinding,
   buildChildProcessEnv,
+  openContainedSessionFileForWrite,
   readContainedSessionFile,
   validateProjectPath,
   validateSidecarSessionDir,
@@ -109,7 +110,7 @@ function spawnSidecarProcess(args, sessionDir) {
   if (sessionDir) {
     try {
       fs.mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
-      stderrFd = fs.openSync(path.join(sessionDir, 'debug.log'), 'w');
+      stderrFd = openContainedSessionFileForWrite(sessionDir, 'debug.log', { mode: 0o600 });
     } catch { /* fall back to ignore */ }
   }
   const child = spawn('node', [sidecarBin, ...args], {

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -8,6 +8,7 @@ const { logger } = require('./utils/logger');
 const { safeSessionDir } = require('./utils/validators');
 const {
   assertContextBinding,
+  buildChildProcessEnv,
   validateProjectPath,
   validateSubagentParent
 } = require('./utils/sidecar-boundaries');
@@ -101,7 +102,10 @@ function spawnSidecarProcess(args, sessionDir) {
   const child = spawn('node', [sidecarBin, ...args], {
     cwd: getProjectDir(),
     stdio: ['ignore', 'ignore', stderrFd],
-    env: { ...process.env, SIDECAR_DEBUG_PORT: '9223', LOG_LEVEL: process.env.LOG_LEVEL || 'info' },
+    env: buildChildProcessEnv({
+      SIDECAR_DEBUG_PORT: '9223',
+      LOG_LEVEL: process.env.LOG_LEVEL || 'info'
+    }),
   });
   child.unref();
   return child;

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -8,6 +8,7 @@ const { logger } = require('./utils/logger');
 const {
   assertContextBinding,
   buildChildProcessEnv,
+  ensureSidecarSessionDir,
   openContainedSessionFileForWrite,
   readContainedSessionFile,
   validateProjectPath,
@@ -109,7 +110,6 @@ function spawnSidecarProcess(args, sessionDir) {
   let stderrFd = 'ignore';
   if (sessionDir) {
     try {
-      fs.mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
       stderrFd = openContainedSessionFileForWrite(sessionDir, 'debug.log', { mode: 0o600 });
     } catch { /* fall back to ignore */ }
   }
@@ -175,7 +175,12 @@ const handlers = {
     if (input.windowPosition)   { args.push('--position', input.windowPosition); }
     args.push('--cwd', cwd);
 
-    const sessionDir = path.join(cwd, '.claude', 'sidecar_sessions', taskId);
+    let sessionDir;
+    try {
+      sessionDir = ensureSidecarSessionDir(cwd, taskId, { allowExisting: false });
+    } catch (err) {
+      return textResult(err.message, true);
+    }
 
     if (sharedServer.enabled && input.noUi) {
       // Shared server path: headless only, delegates to runHeadless()
@@ -192,10 +197,8 @@ const handlers = {
         sessionId = await createSession(client);
 
         // Write initial metadata (MCP handler owns this, runHeadless skips it)
-        fs.mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
-        const metaPath = path.join(sessionDir, 'metadata.json');
         const serverPort = server.url ? new URL(server.url).port : null;
-        fs.writeFileSync(metaPath, JSON.stringify({
+        writeContainedSessionFile(sessionDir, 'metadata.json', JSON.stringify({
           taskId, status: 'running',
           pid: null, // Shared server path: don't store MCP server PID (abort would kill all sessions)
           opencodeSessionId: sessionId,
@@ -233,10 +236,11 @@ const handlers = {
         // Register session with idle eviction
         sharedServer.addSession(sessionId, (_evictedId) => {
           try {
-            const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+            const meta = readMetadataFromSessionDir(sessionDir);
+            if (!meta) { return; }
             meta.status = 'idle-timeout';
             meta.completedAt = new Date().toISOString();
-            fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), { mode: 0o600 });
+            writeContainedSessionFile(sessionDir, 'metadata.json', JSON.stringify(meta, null, 2), { mode: 0o600 });
           } catch (err) {
             logger.warn('Failed to update evicted session metadata', { error: err.message });
           }
@@ -254,8 +258,10 @@ const handlers = {
         ).then((result) => {
           // Session complete - finalize and remove from tracking
           try {
-            const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
-            finalizeSession(sessionDir, result.summary || '', cwd, meta);
+            const meta = readMetadataFromSessionDir(sessionDir);
+            if (meta) {
+              finalizeSession(sessionDir, result.summary || '', cwd, meta);
+            }
           } catch (finErr) {
             logger.warn('Failed to finalize session', { error: finErr.message });
           }
@@ -264,11 +270,12 @@ const handlers = {
           logger.error('Shared server session failed', { taskId, error: err.message });
           sharedServer.removeSession(sessionId);
           try {
-            const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+            const meta = readMetadataFromSessionDir(sessionDir);
+            if (!meta) { return; }
             meta.status = 'error';
             meta.reason = err.message;
             meta.completedAt = new Date().toISOString();
-            fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), { mode: 0o600 });
+            writeContainedSessionFile(sessionDir, 'metadata.json', JSON.stringify(meta, null, 2), { mode: 0o600 });
           } catch (writeErr) {
             logger.warn('Failed to write error metadata', { error: writeErr.message });
           }
@@ -297,10 +304,8 @@ const handlers = {
     }
 
     if (child && child.pid) {
-      fs.mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
-      const metaPath = path.join(sessionDir, 'metadata.json');
-      if (!fs.existsSync(metaPath)) {
-        fs.writeFileSync(metaPath, JSON.stringify({
+      if (readMetadataFromSessionDir(sessionDir) === null) {
+        writeContainedSessionFile(sessionDir, 'metadata.json', JSON.stringify({
           taskId, status: 'running', pid: child.pid, createdAt: new Date().toISOString(),
           project: cwd, projectDir: cwd,
           headless: !!input.noUi,
@@ -487,7 +492,12 @@ const handlers = {
     const cwd = resolveHandlerProject(input, project);
     const { generateTaskId } = require('./sidecar/start');
     const newTaskId = generateTaskId();
-    const sessionDir = path.join(cwd, '.claude', 'sidecar_sessions', newTaskId);
+    let sessionDir;
+    try {
+      sessionDir = ensureSidecarSessionDir(cwd, newTaskId, { allowExisting: false });
+    } catch (err) {
+      return textResult(err.message, true);
+    }
 
     const args = ['continue', input.taskId, '--prompt', input.prompt,
       '--task-id', newTaskId, '--client', 'cowork', '--cwd', cwd];

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -5,11 +5,12 @@ const { spawn } = require('child_process');
 const { getTools, getGuideText } = require('./mcp-tools');
 const { tryResolveModel } = require('./utils/config');
 const { logger } = require('./utils/logger');
-const { safeSessionDir } = require('./utils/validators');
 const {
   assertContextBinding,
   buildChildProcessEnv,
+  readContainedSessionFile,
   validateProjectPath,
+  validateSidecarSessionDir,
   validateSubagentParent
 } = require('./utils/sidecar-boundaries');
 const { readProgress } = require('./sidecar/progress');
@@ -36,11 +37,21 @@ function resolveHandlerProject(input = {}, project) {
 }
 
 /** Read session metadata from disk, or null if not found */
+function readMetadataFromSessionDir(sessionDir) {
+  const metadataText = readContainedSessionFile(sessionDir, 'metadata.json', { optional: true });
+  if (metadataText === null) { return null; }
+  return JSON.parse(metadataText);
+}
+
 function readMetadata(taskId, project) {
-  const sessionDir = safeSessionDir(project, taskId);
-  const metaPath = path.join(sessionDir, 'metadata.json');
-  if (!fs.existsSync(metaPath)) { return null; }
-  return JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+  let sessionDir;
+  try {
+    sessionDir = validateSidecarSessionDir(project, taskId);
+  } catch (err) {
+    if (/not found/i.test(err.message)) { return null; }
+    throw err;
+  }
+  return readMetadataFromSessionDir(sessionDir);
 }
 
 /** Read and validate parent metadata before using subagent files. */
@@ -311,8 +322,14 @@ const handlers = {
 
   async sidecar_status(input, project) {
     const cwd = resolveHandlerProject(input, project);
-    const sessionDir = safeSessionDir(cwd, input.taskId);
-    const metadata = readMetadata(input.taskId, cwd);
+    let sessionDir;
+    let metadata;
+    try {
+      sessionDir = validateSidecarSessionDir(cwd, input.taskId);
+      metadata = readMetadataFromSessionDir(sessionDir);
+    } catch (err) {
+      return textResult(err.message, true);
+    }
     if (!metadata) { return textResult(`Session ${input.taskId} not found.`, true); }
 
     if (metadata.status === 'running' && metadata.pid) {
@@ -363,30 +380,36 @@ const handlers = {
 
   async sidecar_read(input, project) {
     const cwd = resolveHandlerProject(input, project);
-    const sessionDir = safeSessionDir(cwd, input.taskId);
-    if (!fs.existsSync(sessionDir)) {
-      return textResult(`Session ${input.taskId} not found.`, true);
+    let sessionDir;
+    try {
+      sessionDir = validateSidecarSessionDir(cwd, input.taskId);
+    } catch (err) {
+      return textResult(err.message, true);
     }
 
     const mode = input.mode || 'summary';
     if (mode === 'metadata') {
-      return textResult(fs.readFileSync(path.join(sessionDir, 'metadata.json'), 'utf-8'));
+      const metadataText = readContainedSessionFile(sessionDir, 'metadata.json', { optional: true });
+      if (metadataText === null) { return textResult(`Session ${input.taskId} not found.`, true); }
+      return textResult(metadataText);
     }
     if (mode === 'conversation') {
-      const convPath = path.join(sessionDir, 'conversation.jsonl');
-      if (!fs.existsSync(convPath)) { return textResult('No conversation recorded.'); }
-      return textResult(fs.readFileSync(convPath, 'utf-8'));
+      const conversation = readContainedSessionFile(sessionDir, 'conversation.jsonl', { optional: true });
+      if (conversation === null) { return textResult('No conversation recorded.'); }
+      return textResult(conversation);
     }
     // Default: summary
-    const summaryPath = path.join(sessionDir, 'summary.md');
-    if (!fs.existsSync(summaryPath)) {
+    const summaryText = readContainedSessionFile(sessionDir, 'summary.md', { optional: true });
+    if (summaryText === null) {
       return textResult('No summary available (session may still be running or was not folded).');
     }
     const metaForRead = (() => {
-      try { return JSON.parse(fs.readFileSync(path.join(sessionDir, 'metadata.json'), 'utf-8')); }
+      try {
+        const metadataText = readContainedSessionFile(sessionDir, 'metadata.json', { optional: true });
+        return metadataText === null ? {} : JSON.parse(metadataText);
+      }
       catch { return {}; }
     })();
-    const summaryText = fs.readFileSync(summaryPath, 'utf-8');
     const header = metaForRead.model ? `**Model:** ${metaForRead.model}\n\n` : '';
     return textResult(header + summaryText);
   },
@@ -424,7 +447,12 @@ const handlers = {
 
   async sidecar_resume(input, project) {
     const cwd = resolveHandlerProject(input, project);
-    const sessionDir = safeSessionDir(cwd, input.taskId);
+    let sessionDir;
+    try {
+      sessionDir = validateSidecarSessionDir(cwd, input.taskId);
+    } catch (err) {
+      return textResult(err.message, true);
+    }
     const args = ['resume', input.taskId, '--client', 'cowork', '--cwd', cwd];
     if (input.noUi) { args.push('--no-ui', '--agent', 'build'); }
     if (input.timeout) { args.push('--timeout', String(input.timeout)); }
@@ -468,7 +496,14 @@ const handlers = {
 
   async sidecar_abort(input, project) {
     const cwd = resolveHandlerProject(input, project);
-    const metadata = readMetadata(input.taskId, cwd);
+    let sessionDir;
+    let metadata;
+    try {
+      sessionDir = validateSidecarSessionDir(cwd, input.taskId);
+      metadata = readMetadataFromSessionDir(sessionDir);
+    } catch (err) {
+      return textResult(err.message, true);
+    }
     if (!metadata) { return textResult(`Session ${input.taskId} not found.`, true); }
     if (metadata.status !== 'running') {
       return textResult(`Session ${input.taskId} is not running (status: ${metadata.status}).`);
@@ -481,7 +516,6 @@ const handlers = {
         }
       }
     }
-    const sessionDir = safeSessionDir(cwd, input.taskId);
     const metaPath = path.join(sessionDir, 'metadata.json');
     metadata.status = 'aborted';
     metadata.abortedAt = new Date().toISOString();

--- a/src/mcp-tools.js
+++ b/src/mcp-tools.js
@@ -254,6 +254,67 @@ function getTools() {
       'used sidecar before.',
     inputSchema: {},
   },
+  {
+    name: 'sidecar_subagent_start',
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
+    description:
+      'Start a Codex-backed subagent beneath an existing Sidecar task. ' +
+      'Experimental and intended for local/skunk-works use.',
+    inputSchema: {
+      parentTaskId: safeTaskId.describe('Existing parent Sidecar task ID.'),
+      prompt: z.string().describe('Subagent briefing.'),
+      agentType: z.enum(['plan', 'explore', 'build', 'general']).describe(
+        'plan/explore: read-only Codex. build/general: workspace-write Codex. chat is unsupported.'
+      ),
+      model: safeModel.optional().describe('Optional Codex model override.'),
+      project: z.string().optional().describe(
+        'Optional project directory path. Auto-detected from working directory if omitted.'
+      ),
+    },
+  },
+  {
+    name: 'sidecar_subagent_status',
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    description:
+      'Check the status of a Codex-backed subagent beneath an existing Sidecar task.',
+    inputSchema: {
+      parentTaskId: safeTaskId.describe('Existing parent Sidecar task ID.'),
+      subagentId: safeTaskId.describe('The subagent ID returned by sidecar_subagent_start.'),
+      project: z.string().optional().describe(
+        'Optional project directory path. Auto-detected from working directory if omitted.'
+      ),
+    },
+  },
+  {
+    name: 'sidecar_subagent_read',
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    description:
+      'Read the results of a Codex-backed subagent beneath an existing Sidecar task.',
+    inputSchema: {
+      parentTaskId: safeTaskId.describe('Existing parent Sidecar task ID.'),
+      subagentId: safeTaskId.describe('The subagent ID to read.'),
+      mode: z.enum(['summary', 'conversation', 'metadata']).optional()
+        .default('summary').describe(
+          'What to read. summary (default): the folded result. conversation: normalized records. metadata: session info.'
+        ),
+      project: z.string().optional().describe(
+        'Optional project directory path. Auto-detected from working directory if omitted.'
+      ),
+    },
+  },
+  {
+    name: 'sidecar_subagent_abort',
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true, openWorldHint: false },
+    description:
+      'Abort a running Codex-backed subagent beneath an existing Sidecar task.',
+    inputSchema: {
+      parentTaskId: safeTaskId.describe('Existing parent Sidecar task ID.'),
+      subagentId: safeTaskId.describe('The running subagent ID to abort.'),
+      project: z.string().optional().describe(
+        'Optional project directory path. Auto-detected from working directory if omitted.'
+      ),
+    },
+  },
   ];
 }
 
@@ -352,6 +413,8 @@ The sidecar has NO other context. Everything it needs must be in the briefing.
 
 ## Existing Sessions
 Call sidecar_list before spawning. Use sidecar_resume to reopen or sidecar_continue to build on previous findings.
+
+Experimental: \`sidecar_subagent_*\` tools can start Codex-backed subagents under an existing Sidecar task. This is currently intended for local/skunk-works use.
 `;
 }
 

--- a/src/mcp-tools.js
+++ b/src/mcp-tools.js
@@ -48,7 +48,7 @@ function getTools() {
       'For interactive mode, do not poll. Wait for the user to tell you ' +
       'they\'ve clicked Fold, then use sidecar_read. ' +
       'Call sidecar_guide first if you need help choosing a model or writing a good briefing.' +
-      ' Pass includeContext: false when the briefing is fully self-contained.',
+      ' Pass includeContext: true only with an exact parentSession or coworkProcess binding.',
     inputSchema: {
       model: safeModel.optional().describe(
         `Short alias (${aliasNames}) or full provider/model ID. ` +
@@ -89,10 +89,10 @@ function getTools() {
         'Fold summary verbosity. brief: key findings only. normal (default): full ' +
         'structured output. verbose: maximum detail.'
       ),
-      includeContext: z.boolean().optional().default(true).describe(
+      includeContext: z.boolean().optional().default(false).describe(
         'Whether to include parent conversation history as context. '
-        + 'Default: true. Set to false when the briefing is self-contained '
-        + 'and does not depend on prior conversation. See sidecar_guide for guidance.'
+        + 'Default: false. Set to true only when parentSession or coworkProcess '
+        + 'binds the request to the exact parent context. See sidecar_guide for guidance.'
       ),
       coworkProcess: z.string().optional().describe(
         'Cowork VM process name (e.g., "modest-laughing-goodall"). ' +
@@ -382,7 +382,7 @@ Claude Code CLI: pass parentSession with your session UUID.
 
 ## Context Control (includeContext)
 
-By default, sidecar includes your parent conversation history as context. Set \`includeContext: false\` to skip this and save tokens when the briefing is self-contained.
+By default, sidecar does not include parent conversation history. Set \`includeContext: true\` only when passing an exact \`parentSession\` or \`coworkProcess\` binding.
 
 ### MUST Include Context (Red Flags)
 - Task references prior conversation ("the code we discussed", "that bug", "the approach you suggested")
@@ -399,7 +399,7 @@ By default, sidecar includes your parent conversation history as context. Set \`
 - Independent analysis unrelated to current conversation
 
 ### Self-Contained Briefing Template
-When setting \`includeContext: false\`, write a richer briefing:
+When leaving \`includeContext\` false, write a richer briefing:
 
 \`\`\`
 **Objective:** [Specific goal]

--- a/src/opencode-client.js
+++ b/src/opencode-client.js
@@ -27,6 +27,39 @@ async function getCreateOpencodeServer() {
   return sdk.createOpencodeServer;
 }
 
+function normalizeMcpCommand(serverConfig) {
+  if (Array.isArray(serverConfig.command)) {
+    return serverConfig.command.map(String);
+  }
+
+  const cmd = typeof serverConfig.command === 'string'
+    ? serverConfig.command
+    : String(serverConfig.command);
+  const args = Array.isArray(serverConfig.args) ? serverConfig.args.map(String) : [];
+  return [cmd, ...args];
+}
+
+function normalizeLocalMcpConfig(serverConfig) {
+  const { buildMcpServerEnvironment } = require('./utils/sidecar-env');
+  const rest = { ...serverConfig };
+  delete rest.args;
+  delete rest.command;
+  delete rest.env;
+  delete rest.environment;
+  delete rest.type;
+
+  const { env, environment } = serverConfig;
+  const explicitEnvironment = environment !== undefined ? environment : env;
+
+  return {
+    ...rest,
+    type: 'local',
+    enabled: serverConfig.enabled === undefined ? true : serverConfig.enabled,
+    command: normalizeMcpCommand(serverConfig),
+    environment: buildMcpServerEnvironment(explicitEnvironment)
+  };
+}
+
 /**
  * Parse a model string into SDK format
  *
@@ -308,26 +341,22 @@ function buildServerOptions(options = {}) {
   if (options.mcp) {
     // Normalize MCP configs for OpenCode SDK format.
     // Claude Desktop uses {command: "cmd", args: ["a","b"], env: {...}}
-    // OpenCode expects  {type: "local", enabled: true, command: ["cmd","a","b"], env: {...}}
+    // OpenCode expects  {type: "local", enabled: true, command: ["cmd","a","b"], environment: {...}}
     // Key differences:
     //   1. type: "local" (discriminated union, required)
     //   2. enabled: true (required boolean)
     //   3. command: array that includes the binary AND args (merged)
+    //   4. environment: MCP-specific env plus masks for inherited secrets
     const normalized = {};
     for (const [name, serverConfig] of Object.entries(options.mcp)) {
-      if (serverConfig.command && !serverConfig.type) {
+      if (!serverConfig || typeof serverConfig !== 'object') {
+        normalized[name] = serverConfig;
+      } else if (serverConfig.command && (!serverConfig.type || serverConfig.type === 'local')) {
         // Claude Desktop format → OpenCode format
-        const cmd = typeof serverConfig.command === 'string' ? serverConfig.command : String(serverConfig.command);
-        const args = Array.isArray(serverConfig.args) ? serverConfig.args : [];
-        // Note: OpenCode's "local" schema does NOT support an `env` field.
-        // Environment variables from the Claude Desktop config are intentionally
-        // dropped here. The MCP servers inherit the parent process environment
-        // which is usually sufficient.
-        normalized[name] = {
-          type: 'local',
-          enabled: true,
-          command: [cmd, ...args]
-        };
+        // OpenCode merges `environment` over process.env for local MCP servers,
+        // so include explicit masks for ambient secret keys instead of relying
+        // on omitted keys to prevent inheritance.
+        normalized[name] = normalizeLocalMcpConfig(serverConfig);
       } else {
         normalized[name] = serverConfig;
       }

--- a/src/session-manager.js
+++ b/src/session-manager.js
@@ -15,7 +15,9 @@ const SESSION_STATUS = {
   RUNNING: 'running',
   COMPLETE: 'complete',
   ERROR: 'error',
-  TIMEOUT: 'timeout'
+  TIMEOUT: 'timeout',
+  ABORTED: 'aborted',
+  CRASHED: 'crashed'
 };
 
 /**
@@ -255,9 +257,14 @@ function createSubagentSession(projectDir, parentTaskId, subagentId, metadata) {
     parentTaskId,
     agentType: metadata.agentType,
     briefing: metadata.briefing,
-    status: SESSION_STATUS.RUNNING,
-    createdAt: new Date().toISOString(),
-    completedAt: null
+    backend: metadata.backend || 'unknown',
+    status: metadata.status || SESSION_STATUS.RUNNING,
+    sandboxMode: metadata.sandboxMode || null,
+    pid: metadata.pid || null,
+    exitCode: metadata.exitCode ?? null,
+    reason: metadata.reason || null,
+    createdAt: metadata.createdAt || new Date().toISOString(),
+    completedAt: metadata.completedAt || null
   };
 
   // Write metadata
@@ -371,6 +378,29 @@ function saveSubagentSummary(projectDir, parentTaskId, subagentId, summary) {
   });
 }
 
+/**
+ * Append a message to a sub-agent conversation log.
+ *
+ * @param {string} projectDir - Project directory path
+ * @param {string} parentTaskId - Parent sidecar task ID
+ * @param {string} subagentId - Sub-agent ID
+ * @param {object} message - Message to append
+ */
+function appendSubagentConversation(projectDir, parentTaskId, subagentId, message) {
+  const subagentDir = getSubagentDir(projectDir, parentTaskId, subagentId);
+  const convPath = path.join(subagentDir, 'conversation.jsonl');
+
+  if (!fs.existsSync(subagentDir)) {
+    throw new Error(`Sub-agent ${subagentId} not found`);
+  }
+
+  const payload = {
+    ...message,
+    timestamp: message.timestamp || new Date().toISOString()
+  };
+  fs.appendFileSync(convPath, JSON.stringify(payload) + '\n', { mode: 0o600 });
+}
+
 module.exports = {
   createSession,
   updateSession,
@@ -385,5 +415,6 @@ module.exports = {
   updateSubagentSession,
   getSubagentSession,
   listSubagents,
-  saveSubagentSummary
+  saveSubagentSummary,
+  appendSubagentConversation
 };

--- a/src/session-manager.js
+++ b/src/session-manager.js
@@ -8,8 +8,9 @@
 const fs = require('fs');
 const path = require('path');
 const {
+  appendContainedSessionFile,
+  ensureSidecarSessionDir,
   readContainedSessionFile,
-  resolveContainedSessionFile,
   validateSidecarSessionDir,
   validateSidecarSubagentSessionDir,
   writeContainedSessionFile
@@ -63,15 +64,7 @@ function getSessionDir(projectDir, taskId) {
  * @throws {Error} If session already exists
  */
 function createSession(projectDir, taskId, metadata) {
-  const sessionDir = getSessionDir(projectDir, taskId);
-
-  // Check if session already exists
-  if (fs.existsSync(sessionDir)) {
-    throw new Error(`Session ${taskId} already exists`);
-  }
-
-  // Create session directory
-  fs.mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
+  const sessionDir = ensureSidecarSessionDir(projectDir, taskId, { allowExisting: false });
 
   // Build metadata per spec §7.4
   const sessionMetadata = {
@@ -92,14 +85,15 @@ function createSession(projectDir, taskId, metadata) {
   };
 
   // Write metadata.json
-  fs.writeFileSync(
-    path.join(sessionDir, 'metadata.json'),
+  writeContainedSessionFile(
+    sessionDir,
+    'metadata.json',
     JSON.stringify(sessionMetadata, null, 2),
     { mode: 0o600 }
   );
 
   // Create empty conversation.jsonl
-  fs.writeFileSync(path.join(sessionDir, 'conversation.jsonl'), '', { mode: 0o600 });
+  writeContainedSessionFile(sessionDir, 'conversation.jsonl', '', { mode: 0o600 });
 }
 
 /**
@@ -174,12 +168,7 @@ function getSession(projectDir, taskId) {
  * @throws {Error} If session not found
  */
 function saveConversation(projectDir, taskId, message) {
-  const sessionDir = getSessionDir(projectDir, taskId);
-  const convPath = path.join(sessionDir, 'conversation.jsonl');
-
-  if (!fs.existsSync(sessionDir)) {
-    throw new Error(`Session ${taskId} not found`);
-  }
+  const sessionDir = validateSidecarSessionDir(projectDir, taskId);
 
   // Ensure timestamp is present
   const messageWithTimestamp = {
@@ -188,7 +177,12 @@ function saveConversation(projectDir, taskId, message) {
   };
 
   // Append to conversation.jsonl
-  fs.appendFileSync(convPath, JSON.stringify(messageWithTimestamp) + '\n', { mode: 0o600 });
+  appendContainedSessionFile(
+    sessionDir,
+    'conversation.jsonl',
+    JSON.stringify(messageWithTimestamp) + '\n',
+    { mode: 0o600 }
+  );
 }
 
 /**
@@ -417,11 +411,12 @@ function appendSubagentConversation(projectDir, parentTaskId, subagentId, messag
     ...message,
     timestamp: message.timestamp || new Date().toISOString()
   };
-  const conversationPath = path.join(subagentDir, 'conversation.jsonl');
-  const targetPath = fs.existsSync(conversationPath)
-    ? resolveContainedSessionFile(subagentDir, 'conversation.jsonl').path
-    : conversationPath;
-  fs.appendFileSync(targetPath, JSON.stringify(payload) + '\n', { mode: 0o600 });
+  appendContainedSessionFile(
+    subagentDir,
+    'conversation.jsonl',
+    JSON.stringify(payload) + '\n',
+    { mode: 0o600 }
+  );
 }
 
 module.exports = {

--- a/src/session-manager.js
+++ b/src/session-manager.js
@@ -10,6 +10,7 @@ const path = require('path');
 const {
   appendContainedSessionFile,
   ensureSidecarSessionDir,
+  ensureSidecarSubagentSessionDir,
   readContainedSessionFile,
   validateSidecarSessionDir,
   validateSidecarSubagentSessionDir,
@@ -105,15 +106,15 @@ function createSession(projectDir, taskId, metadata) {
  * @throws {Error} If session not found
  */
 function updateSession(projectDir, taskId, updates) {
-  const sessionDir = getSessionDir(projectDir, taskId);
-  const metaPath = path.join(sessionDir, 'metadata.json');
+  const sessionDir = validateSidecarSessionDir(projectDir, taskId);
+  const metadataText = readContainedSessionFile(sessionDir, 'metadata.json', { optional: true });
 
-  if (!fs.existsSync(metaPath)) {
+  if (metadataText === null) {
     throw new Error(`Session ${taskId} not found`);
   }
 
   // Read existing metadata
-  const metadata = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+  const metadata = JSON.parse(metadataText);
 
   // Merge updates
   // For array fields, we append rather than replace
@@ -134,7 +135,7 @@ function updateSession(projectDir, taskId, updates) {
   Object.assign(metadata, updates);
 
   // Write updated metadata
-  fs.writeFileSync(metaPath, JSON.stringify(metadata, null, 2), { mode: 0o600 });
+  writeContainedSessionFile(sessionDir, 'metadata.json', JSON.stringify(metadata, null, 2), { mode: 0o600 });
 }
 
 /**
@@ -145,14 +146,18 @@ function updateSession(projectDir, taskId, updates) {
  * @returns {object|null} Session metadata or null if not found
  */
 function getSession(projectDir, taskId) {
-  const sessionDir = getSessionDir(projectDir, taskId);
-  const metaPath = path.join(sessionDir, 'metadata.json');
-
-  if (!fs.existsSync(metaPath)) {
-    return null;
+  let sessionDir;
+  try {
+    sessionDir = validateSidecarSessionDir(projectDir, taskId);
+  } catch (err) {
+    if (/not found/i.test(err.message)) {
+      return null;
+    }
+    throw err;
   }
 
-  return JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+  const metadataText = readContainedSessionFile(sessionDir, 'metadata.json', { optional: true });
+  return metadataText === null ? null : JSON.parse(metadataText);
 }
 
 /**
@@ -197,15 +202,10 @@ function saveConversation(projectDir, taskId, message) {
  * @throws {Error} If session not found
  */
 function saveSummary(projectDir, taskId, summary) {
-  const sessionDir = getSessionDir(projectDir, taskId);
-  const summaryPath = path.join(sessionDir, 'summary.md');
-
-  if (!fs.existsSync(sessionDir)) {
-    throw new Error(`Session ${taskId} not found`);
-  }
+  const sessionDir = validateSidecarSessionDir(projectDir, taskId);
 
   // Write summary file
-  fs.writeFileSync(summaryPath, summary, { mode: 0o600 });
+  writeContainedSessionFile(sessionDir, 'summary.md', summary, { mode: 0o600 });
 
   // Update session status
   updateSession(projectDir, taskId, {
@@ -247,10 +247,9 @@ function getSubagentDir(projectDir, parentTaskId, subagentId) {
  * @returns {string} Path to the created sub-agent directory
  */
 function createSubagentSession(projectDir, parentTaskId, subagentId, metadata) {
-  const subagentDir = getSubagentDir(projectDir, parentTaskId, subagentId);
-
-  // Create sub-agent directory
-  fs.mkdirSync(subagentDir, { recursive: true, mode: 0o700 });
+  const subagentDir = ensureSidecarSubagentSessionDir(projectDir, parentTaskId, subagentId, {
+    allowExisting: false
+  });
 
   // Build sub-agent metadata
   const subagentMetadata = {
@@ -269,14 +268,15 @@ function createSubagentSession(projectDir, parentTaskId, subagentId, metadata) {
   };
 
   // Write metadata
-  fs.writeFileSync(
-    path.join(subagentDir, 'metadata.json'),
+  writeContainedSessionFile(
+    subagentDir,
+    'metadata.json',
     JSON.stringify(subagentMetadata, null, 2),
     { mode: 0o600 }
   );
 
   // Initialize empty conversation file
-  fs.writeFileSync(path.join(subagentDir, 'conversation.jsonl'), '', { mode: 0o600 });
+  writeContainedSessionFile(subagentDir, 'conversation.jsonl', '', { mode: 0o600 });
 
   return subagentDir;
 }

--- a/src/session-manager.js
+++ b/src/session-manager.js
@@ -7,6 +7,13 @@
 
 const fs = require('fs');
 const path = require('path');
+const {
+  readContainedSessionFile,
+  resolveContainedSessionFile,
+  validateSidecarSessionDir,
+  validateSidecarSubagentSessionDir,
+  writeContainedSessionFile
+} = require('./utils/sidecar-session-boundaries');
 
 /**
  * Session status constants
@@ -289,16 +296,21 @@ function createSubagentSession(projectDir, parentTaskId, subagentId, metadata) {
  * @param {object} updates - Fields to update
  */
 function updateSubagentSession(projectDir, parentTaskId, subagentId, updates) {
-  const subagentDir = getSubagentDir(projectDir, parentTaskId, subagentId);
-  const metadataPath = path.join(subagentDir, 'metadata.json');
+  const subagentDir = validateSidecarSubagentSessionDir(projectDir, parentTaskId, subagentId);
+  const metadataText = readContainedSessionFile(subagentDir, 'metadata.json', { optional: true });
 
-  if (!fs.existsSync(metadataPath)) {
+  if (metadataText === null) {
     throw new Error(`Sub-agent ${subagentId} not found`);
   }
 
-  const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf-8'));
+  const metadata = JSON.parse(metadataText);
   const updated = { ...metadata, ...updates };
-  fs.writeFileSync(metadataPath, JSON.stringify(updated, null, 2), { mode: 0o600 });
+  writeContainedSessionFile(
+    subagentDir,
+    'metadata.json',
+    JSON.stringify(updated, null, 2),
+    { mode: 0o600 }
+  );
 }
 
 /**
@@ -310,13 +322,22 @@ function updateSubagentSession(projectDir, parentTaskId, subagentId, updates) {
  * @returns {object|null} Sub-agent metadata or null if not found
  */
 function getSubagentSession(projectDir, parentTaskId, subagentId) {
-  const metadataPath = path.join(getSubagentDir(projectDir, parentTaskId, subagentId), 'metadata.json');
+  let subagentDir;
+  try {
+    subagentDir = validateSidecarSubagentSessionDir(projectDir, parentTaskId, subagentId);
+  } catch (err) {
+    if (/not found/i.test(err.message)) {
+      return null;
+    }
+    throw err;
+  }
 
-  if (!fs.existsSync(metadataPath)) {
+  const metadataText = readContainedSessionFile(subagentDir, 'metadata.json', { optional: true });
+  if (metadataText === null) {
     return null;
   }
 
-  return JSON.parse(fs.readFileSync(metadataPath, 'utf-8'));
+  return JSON.parse(metadataText);
 }
 
 /**
@@ -330,20 +351,24 @@ function getSubagentSession(projectDir, parentTaskId, subagentId) {
  * @returns {object[]} Array of sub-agent metadata
  */
 function listSubagents(projectDir, parentTaskId, filter = {}) {
-  const subagentsDir = path.join(getSessionDir(projectDir, parentTaskId), 'subagents');
+  let parentDir;
+  try {
+    parentDir = validateSidecarSessionDir(projectDir, parentTaskId);
+  } catch {
+    return [];
+  }
+  const subagentsDir = path.join(parentDir, 'subagents');
 
   if (!fs.existsSync(subagentsDir)) {
     return [];
   }
 
-  const subagentIds = fs.readdirSync(subagentsDir).filter(name => {
-    const stat = fs.statSync(path.join(subagentsDir, name));
-    return stat.isDirectory();
-  });
-
-  let subagents = subagentIds.map(id => {
-    const metadata = getSubagentSession(projectDir, parentTaskId, id);
-    return metadata;
+  let subagents = fs.readdirSync(subagentsDir).map(id => {
+    try {
+      return getSubagentSession(projectDir, parentTaskId, id);
+    } catch {
+      return null;
+    }
   }).filter(Boolean);
 
   // Apply filters
@@ -366,10 +391,9 @@ function listSubagents(projectDir, parentTaskId, filter = {}) {
  * @param {string} summary - Summary content
  */
 function saveSubagentSummary(projectDir, parentTaskId, subagentId, summary) {
-  const subagentDir = getSubagentDir(projectDir, parentTaskId, subagentId);
-  const summaryPath = path.join(subagentDir, 'summary.md');
+  const subagentDir = validateSidecarSubagentSessionDir(projectDir, parentTaskId, subagentId);
 
-  fs.writeFileSync(summaryPath, summary, { mode: 0o600 });
+  writeContainedSessionFile(subagentDir, 'summary.md', summary, { mode: 0o600 });
 
   // Update sub-agent status
   updateSubagentSession(projectDir, parentTaskId, subagentId, {
@@ -387,18 +411,17 @@ function saveSubagentSummary(projectDir, parentTaskId, subagentId, summary) {
  * @param {object} message - Message to append
  */
 function appendSubagentConversation(projectDir, parentTaskId, subagentId, message) {
-  const subagentDir = getSubagentDir(projectDir, parentTaskId, subagentId);
-  const convPath = path.join(subagentDir, 'conversation.jsonl');
-
-  if (!fs.existsSync(subagentDir)) {
-    throw new Error(`Sub-agent ${subagentId} not found`);
-  }
+  const subagentDir = validateSidecarSubagentSessionDir(projectDir, parentTaskId, subagentId);
 
   const payload = {
     ...message,
     timestamp: message.timestamp || new Date().toISOString()
   };
-  fs.appendFileSync(convPath, JSON.stringify(payload) + '\n', { mode: 0o600 });
+  const conversationPath = path.join(subagentDir, 'conversation.jsonl');
+  const targetPath = fs.existsSync(conversationPath)
+    ? resolveContainedSessionFile(subagentDir, 'conversation.jsonl').path
+    : conversationPath;
+  fs.appendFileSync(targetPath, JSON.stringify(payload) + '\n', { mode: 0o600 });
 }
 
 module.exports = {

--- a/src/session-manager.js
+++ b/src/session-manager.js
@@ -13,6 +13,7 @@ const {
   ensureSidecarSubagentSessionDir,
   readContainedSessionFile,
   validateSidecarSessionDir,
+  validateSidecarSubagentsRoot,
   validateSidecarSubagentSessionDir,
   writeContainedSessionFile
 } = require('./utils/sidecar-session-boundaries');
@@ -345,15 +346,14 @@ function getSubagentSession(projectDir, parentTaskId, subagentId) {
  * @returns {object[]} Array of sub-agent metadata
  */
 function listSubagents(projectDir, parentTaskId, filter = {}) {
-  let parentDir;
+  let subagentsDir;
   try {
-    parentDir = validateSidecarSessionDir(projectDir, parentTaskId);
+    subagentsDir = validateSidecarSubagentsRoot(projectDir, parentTaskId, { optional: true });
   } catch {
     return [];
   }
-  const subagentsDir = path.join(parentDir, 'subagents');
 
-  if (!fs.existsSync(subagentsDir)) {
+  if (subagentsDir === null) {
     return [];
   }
 

--- a/src/sidecar/context-builder.js
+++ b/src/sidecar/context-builder.js
@@ -12,7 +12,7 @@ const os = require('os');
 const { resolveSession, getSessionDirectory } = require('../session');
 const { formatContext, readJSONL } = require('../jsonl-parser');
 const { logger } = require('../utils/logger');
-const { resolveContextSessionScope } = require('../utils/sidecar-boundaries');
+const { resolveExactSessionFile, resolveContextSessionScope } = require('../utils/sidecar-boundaries');
 
 /**
  * Parse duration string (e.g., '2h', '30m', '1d')
@@ -31,14 +31,11 @@ function parseDuration(str) {
   return parseInt(match[1], 10) * multipliers[match[2]];
 }
 
-/**
- * Resolve session file from session directory
- * @param {string} sessionDir - Session directory path
- * @param {string} session - Session ID or 'current'
- * @returns {{path: string|null, method: string, warning?: string}}
- */
-function resolveSessionFile(sessionDir, session) {
-  // Use the existing resolveSession function
+/** Resolve a session file, optionally requiring an exact match. */
+function resolveSessionFile(sessionDir, session, options = {}) {
+  if (options.exactSession) {
+    return resolveExactSessionFile(sessionDir, session);
+  }
   return resolveSession(sessionDir, session);
 }
 
@@ -189,6 +186,7 @@ function buildContext(project, session, options = {}) {
     client,
     coworkProcess,
     parentProject,
+    exactSession = false,
     _homeDir
   } = options;
   const homeDir = _homeDir || os.homedir();
@@ -236,12 +234,15 @@ function buildContext(project, session, options = {}) {
   }
 
   if (!fs.existsSync(resolvedSessionDir)) {
+    if (exactSession) {
+      throw new Error(`Exact session ${session} not found`);
+    }
     logger.warn('No Claude Code conversation history found', { project, sessionDir: resolvedSessionDir, client });
     return '[No Claude Code conversation history found]';
   }
 
   // Resolve session file
-  const resolution = resolveSessionFile(resolvedSessionDir, session);
+  const resolution = resolveSessionFile(resolvedSessionDir, session, { exactSession });
 
   if (!resolution.path) {
     logger.warn('No Claude Code session found', { project, session });
@@ -289,6 +290,7 @@ module.exports = {
   buildContext,
   parseDuration,
   resolveSessionFile,
+  resolveExactSessionFile,
   applyContextFilters,
   findCoworkSession,
   normalizeCoworkMessages,

--- a/src/sidecar/context-builder.js
+++ b/src/sidecar/context-builder.js
@@ -205,6 +205,7 @@ function buildContext(project, session, options = {}) {
     }
     const auditPath = findCoworkSession(homeDir, coworkProcess);
     if (!auditPath) {
+      if (exactSession) { throw new Error(`Cowork session for process ${coworkProcess} not found`); }
       logger.warn('No Cowork session found in local-agent-mode-sessions', { project: validatedProject });
       return '[No Claude Code conversation history found]';
     }

--- a/src/sidecar/context-builder.js
+++ b/src/sidecar/context-builder.js
@@ -12,6 +12,7 @@ const os = require('os');
 const { resolveSession, getSessionDirectory } = require('../session');
 const { formatContext, readJSONL } = require('../jsonl-parser');
 const { logger } = require('../utils/logger');
+const { resolveContextSessionScope } = require('../utils/sidecar-boundaries');
 
 /**
  * Parse duration string (e.g., '2h', '30m', '1d')
@@ -178,37 +179,35 @@ function normalizeCoworkMessages(messages) {
     }));
 }
 
-/**
- * Build context from Claude Code session
- * Spec Reference: §5 Context Passing
- *
- * @param {string} project - Project directory
- * @param {string} session - Session ID or 'current'
- * @param {object} options - Context options
- * @param {number} [options.contextTurns=50] - Max conversation turns
- * @param {string} [options.contextSince] - Time filter (e.g., '2h')
- * @param {number} [options.contextMaxTokens=80000] - Max context tokens
- * @param {string} [options.sessionDir] - Explicit session directory override (for code-web, cowork)
- * @param {string} [options.client] - Client type (code-local, code-web, cowork)
- * @param {string} [options._homeDir] - Home directory override (testing only)
- * @returns {string} Formatted context string
- */
-function buildContext(project, session, options) {
-  const { contextTurns = 50, contextSince, contextMaxTokens = 80000, sessionDir: sessionDirOverride, client, coworkProcess, _homeDir } = options;
+/** Build context from Claude Code or Cowork session history. */
+function buildContext(project, session, options = {}) {
+  const {
+    contextTurns = 50,
+    contextSince,
+    contextMaxTokens = 80000,
+    sessionDir: sessionDirOverride,
+    client,
+    coworkProcess,
+    parentProject,
+    _homeDir
+  } = options;
   const homeDir = _homeDir || os.homedir();
+  const { validatedProject, resolvedSessionDir } = resolveContextSessionScope({
+    project,
+    parentProject,
+    sessionDir: sessionDirOverride,
+    homeDir,
+    getSessionDirectory
+  });
 
-  // Determine session directory:
-  // 1. If sessionDir is explicitly provided, use it directly (code-web, cowork)
-  // 2. Otherwise, use the standard getSessionDirectory for code-local
-  const resolvedSessionDir = sessionDirOverride || getSessionDirectory(project, homeDir);
-
-  // For cowork clients: read directly from Cowork's local-agent-mode-sessions
-  // on the host Mac. The Cowork VM can't expose its session path to the MCP server,
-  // so we find the most recently active session's audit.jsonl on the host.
+  // Cowork context comes from Claude Desktop's host-side audit log.
   if (client === 'cowork' && !sessionDirOverride) {
+    if (!coworkProcess) {
+      throw new Error('Cowork context requires coworkProcess for exact session matching');
+    }
     const auditPath = findCoworkSession(homeDir, coworkProcess);
     if (!auditPath) {
-      logger.warn('No Cowork session found in local-agent-mode-sessions', { project });
+      logger.warn('No Cowork session found in local-agent-mode-sessions', { project: validatedProject });
       return '[No Claude Code conversation history found]';
     }
 

--- a/src/sidecar/continue.js
+++ b/src/sidecar/continue.js
@@ -19,7 +19,8 @@ const { buildPrompts } = require('../prompt-builder');
 const { logger } = require('../utils/logger');
 const {
   validateSidecarSessionDir,
-  validateSidecarSessionMetadata
+  validateSidecarSessionMetadata,
+  readContainedSessionFile
 } = require('../utils/sidecar-boundaries');
 
 /** Load previous session data (metadata, summary, conversation) */
@@ -27,22 +28,20 @@ function loadPreviousSession(taskId, project) {
   const sessionDir = validateSidecarSessionDir(project, taskId);
 
   // Load metadata
-  const metaPath = SessionPaths.metadataFile(sessionDir);
   const metadata = validateSidecarSessionMetadata(
-    JSON.parse(fs.readFileSync(metaPath, 'utf-8')),
+    JSON.parse(readContainedSessionFile(sessionDir, 'metadata.json')),
     project
   );
 
   // Load summary if available
-  const summaryPath = SessionPaths.summaryFile(sessionDir);
-  const summary = fs.existsSync(summaryPath) ? fs.readFileSync(summaryPath, 'utf-8') : '';
+  const summary = readContainedSessionFile(sessionDir, 'summary.md', { optional: true }) || '';
 
   // Load and format conversation if available
-  const convPath = SessionPaths.conversationFile(sessionDir);
+  const conversationText = readContainedSessionFile(sessionDir, 'conversation.jsonl', { optional: true });
   let conversation = '';
 
-  if (fs.existsSync(convPath)) {
-    const lines = fs.readFileSync(convPath, 'utf-8').split('\n').filter(Boolean);
+  if (conversationText !== null) {
+    const lines = conversationText.split('\n').filter(Boolean);
     const messages = lines.map(line => {
       try { return JSON.parse(line); } catch { return null; }
     }).filter(Boolean);
@@ -91,7 +90,8 @@ function createContinueSessionMetadata(taskId, project, options, oldTaskId) {
   const { model, briefing, headless, agent } = options;
 
   const sessionDir = SessionPaths.sessionDir(project, taskId);
-  fs.mkdirSync(sessionDir, { recursive: true });
+  fs.mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
+  fs.chmodSync(sessionDir, 0o700);
 
   const metadata = {
     taskId,
@@ -106,7 +106,9 @@ function createContinueSessionMetadata(taskId, project, options, oldTaskId) {
     continuesFrom: oldTaskId
   };
 
-  fs.writeFileSync(SessionPaths.metadataFile(sessionDir), JSON.stringify(metadata, null, 2));
+  const metaPath = SessionPaths.metadataFile(sessionDir);
+  fs.writeFileSync(metaPath, JSON.stringify(metadata, null, 2), { mode: 0o600 });
+  fs.chmodSync(metaPath, 0o600);
 
   return sessionDir;
 }

--- a/src/sidecar/continue.js
+++ b/src/sidecar/continue.js
@@ -18,9 +18,11 @@ const { runHeadless } = require('../headless');
 const { buildPrompts } = require('../prompt-builder');
 const { logger } = require('../utils/logger');
 const {
+  ensureSidecarSessionDir,
   validateSidecarSessionDir,
   validateSidecarSessionMetadata,
-  readContainedSessionFile
+  readContainedSessionFile,
+  writeContainedSessionFile
 } = require('../utils/sidecar-boundaries');
 
 /** Load previous session data (metadata, summary, conversation) */
@@ -89,8 +91,7 @@ Build on the previous sidecar's findings. The user wants to continue or extend t
 function createContinueSessionMetadata(taskId, project, options, oldTaskId) {
   const { model, briefing, headless, agent } = options;
 
-  const sessionDir = SessionPaths.sessionDir(project, taskId);
-  fs.mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
+  const sessionDir = ensureSidecarSessionDir(project, taskId);
   fs.chmodSync(sessionDir, 0o700);
 
   const metadata = {
@@ -107,7 +108,7 @@ function createContinueSessionMetadata(taskId, project, options, oldTaskId) {
   };
 
   const metaPath = SessionPaths.metadataFile(sessionDir);
-  fs.writeFileSync(metaPath, JSON.stringify(metadata, null, 2), { mode: 0o600 });
+  writeContainedSessionFile(sessionDir, 'metadata.json', JSON.stringify(metadata, null, 2), { mode: 0o600 });
   fs.chmodSync(metaPath, 0o600);
 
   return sessionDir;
@@ -201,8 +202,7 @@ async function continueSidecar(options) {
   outputSummary(summary);
 
   // Load current metadata for finalization
-  const metaPath = SessionPaths.metadataFile(sessionDir);
-  const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+  const meta = JSON.parse(readContainedSessionFile(sessionDir, 'metadata.json'));
 
   // Finalize session
   finalizeSession(sessionDir, summary, effectiveProject, meta);

--- a/src/sidecar/continue.js
+++ b/src/sidecar/continue.js
@@ -17,18 +17,21 @@ const { acquireLock, releaseLock } = require('../utils/session-lock');
 const { runHeadless } = require('../headless');
 const { buildPrompts } = require('../prompt-builder');
 const { logger } = require('../utils/logger');
+const {
+  validateSidecarSessionDir,
+  validateSidecarSessionMetadata
+} = require('../utils/sidecar-boundaries');
 
 /** Load previous session data (metadata, summary, conversation) */
 function loadPreviousSession(taskId, project) {
-  const sessionDir = SessionPaths.sessionDir(project, taskId);
-
-  if (!fs.existsSync(sessionDir)) {
-    throw new Error(`Session ${taskId} not found`);
-  }
+  const sessionDir = validateSidecarSessionDir(project, taskId);
 
   // Load metadata
   const metaPath = SessionPaths.metadataFile(sessionDir);
-  const metadata = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+  const metadata = validateSidecarSessionMetadata(
+    JSON.parse(fs.readFileSync(metaPath, 'utf-8')),
+    project
+  );
 
   // Load summary if available
   const summaryPath = SessionPaths.summaryFile(sessionDir);
@@ -50,7 +53,7 @@ function loadPreviousSession(taskId, project) {
     }).join('\n\n');
   }
 
-  return { metadata, summary, conversation };
+  return { metadata, summary, conversation, sessionDir };
 }
 
 /** Build continuation context from previous session data */
@@ -94,6 +97,7 @@ function createContinueSessionMetadata(taskId, project, options, oldTaskId) {
     taskId,
     model,
     project,
+    projectDir: project,
     briefing,
     mode: headless ? 'headless' : 'interactive',
     agent: agent || (headless ? 'build' : 'chat'),
@@ -121,11 +125,16 @@ async function continueSidecar(options) {
   } = options;
 
   // Load previous session data
-  const { metadata: oldMetadata, summary: previousSummary, conversation: previousConversation } =
+  const {
+    metadata: oldMetadata,
+    summary: previousSummary,
+    conversation: previousConversation,
+    sessionDir: prevSessionDir
+  } =
     loadPreviousSession(oldTaskId, project);
+  const effectiveProject = oldMetadata.projectDir;
 
   // Lock the previous session directory to prevent concurrent continue operations from the same source
-  const prevSessionDir = SessionPaths.sessionDir(project, oldTaskId);
   acquireLock(prevSessionDir, headless ? 'headless' : 'interactive');
 
   const model = options.model || oldMetadata.model;
@@ -143,14 +152,14 @@ async function continueSidecar(options) {
 
   // Build system prompt and user message
   const { system: systemPrompt, userMessage } = buildPrompts(
-    briefing, fullContext, project, headless, effectiveAgent, 'normal', client
+    briefing, fullContext, effectiveProject, headless, effectiveAgent, 'normal', client
   );
 
   // Use provided task ID (from MCP server) or generate a new one
   const newTaskId = options.newTaskId || generateTaskId();
   logger.info('New continuation task', { newTaskId, oldTaskId });
 
-  const sessionDir = createContinueSessionMetadata(newTaskId, project, {
+  const sessionDir = createContinueSessionMetadata(newTaskId, effectiveProject, {
     model, briefing, headless, agent: effectiveAgent
   }, oldTaskId);
 
@@ -164,7 +173,7 @@ async function continueSidecar(options) {
   try {
     if (headless) {
       const result = await runHeadless(
-        model, systemPrompt, userMessage, newTaskId, project,
+        model, systemPrompt, userMessage, newTaskId, effectiveProject,
         timeout * 60 * 1000, effectiveAgent, { mcp: mcpServers }
       );
       summary = result.summary ||
@@ -175,7 +184,7 @@ async function continueSidecar(options) {
     } else {
       logger.info('Launching interactive continue', { taskId: newTaskId, model });
       const result = await runInteractive(
-        model, systemPrompt, userMessage, newTaskId, project,
+        model, systemPrompt, userMessage, newTaskId, effectiveProject,
         { agent: effectiveAgent, mcp: mcpServers }
       );
       summary = result.summary || '';
@@ -194,7 +203,7 @@ async function continueSidecar(options) {
   const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
 
   // Finalize session
-  finalizeSession(sessionDir, summary, project, meta);
+  finalizeSession(sessionDir, summary, effectiveProject, meta);
 }
 
 module.exports = {

--- a/src/sidecar/crash-handler.js
+++ b/src/sidecar/crash-handler.js
@@ -8,7 +8,11 @@
 
 const fs = require('fs');
 const path = require('path');
-const { SessionPaths } = require('./session-utils');
+const {
+  readContainedSessionFile,
+  validateSidecarSessionDir,
+  writeContainedSessionFile
+} = require('../utils/sidecar-session-boundaries');
 
 /**
  * Create a crash handler that updates session metadata on error.
@@ -20,14 +24,14 @@ const { SessionPaths } = require('./session-utils');
 function installCrashHandler(taskId, project) {
   return function handleCrash(err) {
     try {
-      const sessionDir = SessionPaths.sessionDir(project, taskId);
-      const metaPath = SessionPaths.metadataFile(sessionDir);
+      const sessionDir = validateSidecarSessionDir(project, taskId);
+      const metadataText = readContainedSessionFile(sessionDir, 'metadata.json', { optional: true });
 
-      if (!fs.existsSync(metaPath)) {
+      if (metadataText === null) {
         return;
       }
 
-      const metadata = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+      const metadata = JSON.parse(metadataText);
 
       if (metadata.status !== 'running') {
         return;
@@ -37,7 +41,7 @@ function installCrashHandler(taskId, project) {
       metadata.reason = err.message;
       metadata.errorAt = new Date().toISOString();
 
-      fs.writeFileSync(metaPath, JSON.stringify(metadata, null, 2), { mode: 0o600 });
+      writeContainedSessionFile(sessionDir, 'metadata.json', JSON.stringify(metadata, null, 2), { mode: 0o600 });
 
       // Delete session lock if it exists
       const lockPath = path.join(sessionDir, 'session.lock');

--- a/src/sidecar/interactive.js
+++ b/src/sidecar/interactive.js
@@ -9,6 +9,7 @@ const { spawn } = require('child_process');
 const { startOpenCodeServer } = require('./session-utils');
 const { createSession, sendPromptAsync } = require('../opencode-client');
 const { mapAgentToOpenCode } = require('../utils/agent-mapping');
+const { buildChildProcessEnv } = require('../utils/sidecar-env');
 const { logger } = require('../utils/logger');
 
 /** Get the Electron binary path via require('electron').
@@ -30,13 +31,12 @@ function checkElectronAvailable() {
 /** Build environment variables for Electron process */
 function buildElectronEnv(taskId, model, project, nodeModulesBin, existingPath, options = {}) {
   const { agent, isResume, conversation, mcp, client, windowPosition } = options;
-  const env = {
-    ...process.env,
+  const env = buildChildProcessEnv({
     PATH: `${nodeModulesBin}:${existingPath}`,
     SIDECAR_TASK_ID: taskId,
     SIDECAR_MODEL: model,
     SIDECAR_PROJECT: project
-  };
+  });
 
   if (client) { env.SIDECAR_CLIENT = client; }
   if (windowPosition) { env.SIDECAR_WINDOW_POSITION = windowPosition; }

--- a/src/sidecar/progress.js
+++ b/src/sidecar/progress.js
@@ -7,7 +7,10 @@
  */
 
 const fs = require('fs');
-const path = require('path');
+const {
+  resolveContainedSessionFile,
+  writeContainedSessionFile
+} = require('../utils/sidecar-session-boundaries');
 
 /** Lifecycle stage labels */
 const STAGE_LABELS = {
@@ -95,14 +98,28 @@ function computeLastActivity(mtime) {
  * @param {object} [extra={}] - Additional fields (e.g., messagesReceived)
  */
 function writeProgress(sessionDir, stage, extra = {}) {
-  const progressPath = path.join(sessionDir, 'progress.json');
   const data = {
     stage,
     stageLabel: STAGE_LABELS[stage] || stage,
     updatedAt: new Date().toISOString(),
     ...extra
   };
-  fs.writeFileSync(progressPath, JSON.stringify(data), { mode: 0o600 });
+  writeContainedSessionFile(sessionDir, 'progress.json', JSON.stringify(data), { mode: 0o600 });
+}
+
+function readOptionalProgressInput(sessionDir, filename) {
+  try {
+    const resolved = resolveContainedSessionFile(sessionDir, filename, { optional: true });
+    if (resolved === null) {
+      return null;
+    }
+    return {
+      content: fs.readFileSync(resolved.path, 'utf-8'),
+      stat: resolved.stat
+    };
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -112,18 +129,15 @@ function writeProgress(sessionDir, stage, extra = {}) {
  * @returns {{ messages: number, lastActivity: string, latest: string, stage?: string }}
  */
 function readProgress(sessionDir) {
-  const convPath = path.join(sessionDir, 'conversation.jsonl');
-  const progressPath = path.join(sessionDir, 'progress.json');
-
   let convStat = null;
   const entries = [];
+  const conversation = readOptionalProgressInput(sessionDir, 'conversation.jsonl');
+  const progressInput = readOptionalProgressInput(sessionDir, 'progress.json');
 
   // Read conversation.jsonl if it exists
-  if (fs.existsSync(convPath)) {
-    convStat = fs.statSync(convPath);
-    const content = fs.readFileSync(convPath, 'utf-8');
-
-    for (const line of content.split('\n')) {
+  if (conversation) {
+    convStat = conversation.stat;
+    for (const line of conversation.content.split('\n')) {
       if (!line.trim()) {
         continue;
       }
@@ -149,9 +163,9 @@ function readProgress(sessionDir) {
   // Read progress.json for lifecycle stage info
   let stage;
 
-  if (fs.existsSync(progressPath)) {
+  if (progressInput) {
     try {
-      const progress = JSON.parse(fs.readFileSync(progressPath, 'utf-8'));
+      const progress = JSON.parse(progressInput.content);
       stage = progress.stage;
 
       // Use progress stage label when no assistant entries exist yet
@@ -188,9 +202,9 @@ function readProgress(sessionDir) {
     lastActivityMs = Date.now() - convStat.mtime.getTime();
   }
   // Use progress.json updatedAt if more recent
-  if (fs.existsSync(progressPath)) {
+  if (progressInput) {
     try {
-      const progress = JSON.parse(fs.readFileSync(progressPath, 'utf-8'));
+      const progress = JSON.parse(progressInput.content);
       if (progress.updatedAt) {
         const progressMs = Date.now() - new Date(progress.updatedAt).getTime();
         if (lastActivityMs === null || progressMs < lastActivityMs) {

--- a/src/sidecar/read.js
+++ b/src/sidecar/read.js
@@ -6,8 +6,12 @@
  */
 
 const fs = require('fs');
-const path = require('path');
-const { safeSessionDir, TASK_ID_PATTERN } = require('../utils/validators');
+const { TASK_ID_PATTERN } = require('../utils/validators');
+const {
+  readContainedSessionFile,
+  validateSidecarSessionDir,
+  validateSidecarSessionsRoot
+} = require('../utils/sidecar-session-boundaries');
 
 /**
  * Format a timestamp as relative age
@@ -40,24 +44,28 @@ function formatAge(dateStr) {
 async function listSidecars(options) {
   const { status, json, project = process.cwd() } = options;
 
-  const sessionsDir = path.join(project, '.claude', 'sidecar_sessions');
+  let sessionsDir;
+  try {
+    sessionsDir = validateSidecarSessionsRoot(project);
+  } catch (err) {
+    if (!/does not exist/i.test(err.message)) {
+      throw err;
+    }
+  }
 
-  if (!fs.existsSync(sessionsDir)) {
+  if (!sessionsDir) {
     console.log('No sidecar sessions found.');
     return;
   }
 
   let sessions = fs.readdirSync(sessionsDir)
     .filter(d => TASK_ID_PATTERN.test(d))
-    .filter(d => {
-      const metaPath = path.join(sessionsDir, d, 'metadata.json');
-      return fs.existsSync(metaPath);
-    })
     .map(d => {
       try {
-        const meta = JSON.parse(
-          fs.readFileSync(path.join(sessionsDir, d, 'metadata.json'), 'utf-8')
-        );
+        const sessionDir = validateSidecarSessionDir(project, d);
+        const metadataText = readContainedSessionFile(sessionDir, 'metadata.json', { optional: true });
+        if (metadataText === null) { return null; }
+        const meta = JSON.parse(metadataText);
         return {
           id: d, model: meta.model, status: meta.status, agent: meta.agent,
           briefing: meta.briefing, createdAt: meta.createdAt,
@@ -112,16 +120,12 @@ async function listSidecars(options) {
 async function readSidecar(options) {
   const { taskId, conversation, metadata, project = process.cwd() } = options;
 
-  const sessionDir = safeSessionDir(project, taskId);
-
-  if (!fs.existsSync(sessionDir)) {
-    throw new Error(`Session ${taskId} not found`);
-  }
+  const sessionDir = validateSidecarSessionDir(project, taskId);
 
   if (conversation) {
-    const convPath = path.join(sessionDir, 'conversation.jsonl');
-    if (fs.existsSync(convPath)) {
-      const lines = fs.readFileSync(convPath, 'utf-8').split('\n').filter(Boolean);
+    const conversationText = readContainedSessionFile(sessionDir, 'conversation.jsonl', { optional: true });
+    if (conversationText !== null) {
+      const lines = conversationText.split('\n').filter(Boolean);
       lines.forEach(line => {
         try {
           const msg = JSON.parse(line);
@@ -135,13 +139,12 @@ async function readSidecar(options) {
       console.log('No conversation recorded.');
     }
   } else if (metadata) {
-    const metaPath = path.join(sessionDir, 'metadata.json');
-    console.log(fs.readFileSync(metaPath, 'utf-8'));
+    console.log(readContainedSessionFile(sessionDir, 'metadata.json'));
   } else {
     // Default: show summary
-    const summaryPath = path.join(sessionDir, 'summary.md');
-    if (fs.existsSync(summaryPath)) {
-      console.log(fs.readFileSync(summaryPath, 'utf-8'));
+    const summaryText = readContainedSessionFile(sessionDir, 'summary.md', { optional: true });
+    if (summaryText !== null) {
+      console.log(summaryText);
     } else {
       console.log('No summary available (session may not have been folded).');
     }

--- a/src/sidecar/resume.js
+++ b/src/sidecar/resume.js
@@ -19,7 +19,8 @@ const { runHeadless } = require('../headless');
 const { logger } = require('../utils/logger');
 const {
   validateSidecarSessionDir,
-  validateSidecarSessionMetadata
+  validateSidecarSessionMetadata,
+  readContainedSessionFile
 } = require('../utils/sidecar-boundaries');
 
 /** Load session metadata from session directory */
@@ -28,16 +29,12 @@ function loadSessionMetadata(sessionDir) {
   if (!fs.existsSync(metaPath)) {
     throw new Error(`Session metadata not found: ${metaPath}`);
   }
-  return JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+  return JSON.parse(readContainedSessionFile(sessionDir, 'metadata.json'));
 }
 
 /** Load initial context (system prompt) from session */
 function loadInitialContext(sessionDir) {
-  const contextPath = SessionPaths.contextFile(sessionDir);
-  if (fs.existsSync(contextPath)) {
-    return fs.readFileSync(contextPath, 'utf-8');
-  }
-  return '';
+  return readContainedSessionFile(sessionDir, 'initial_context.md', { optional: true }) || '';
 }
 
 /** Check for file drift - files that were read may have changed */
@@ -164,10 +161,8 @@ async function resumeSidecar(options) {
     const effectiveAgent = metadata.agent || 'Build';
 
     // Load conversation for both paths (interactive already did this, headless didn't)
-    const conversationPath = SessionPaths.conversationFile(sessionDir);
-    const existingConversation = fs.existsSync(conversationPath)
-      ? fs.readFileSync(conversationPath, 'utf-8')
-      : '';
+    const existingConversation =
+      readContainedSessionFile(sessionDir, 'conversation.jsonl', { optional: true }) || '';
 
     if (headless) {
       const userMessage = buildResumeUserMessage(metadata.briefing || '', existingConversation);

--- a/src/sidecar/resume.js
+++ b/src/sidecar/resume.js
@@ -20,16 +20,26 @@ const { logger } = require('../utils/logger');
 const {
   validateSidecarSessionDir,
   validateSidecarSessionMetadata,
-  readContainedSessionFile
+  readContainedSessionFile,
+  writeContainedSessionFile
 } = require('../utils/sidecar-boundaries');
 
 /** Load session metadata from session directory */
 function loadSessionMetadata(sessionDir) {
   const metaPath = SessionPaths.metadataFile(sessionDir);
-  if (!fs.existsSync(metaPath)) {
+  let metadataText;
+  try {
+    metadataText = readContainedSessionFile(sessionDir, 'metadata.json', { optional: true });
+  } catch (err) {
+    if (/Session directory .*does not exist|Session file not found/i.test(err.message)) {
+      throw new Error(`Session metadata not found: ${metaPath}`);
+    }
+    throw err;
+  }
+  if (metadataText === null) {
     throw new Error(`Session metadata not found: ${metaPath}`);
   }
-  return JSON.parse(readContainedSessionFile(sessionDir, 'metadata.json'));
+  return JSON.parse(metadataText);
 }
 
 /** Load initial context (system prompt) from session */
@@ -101,13 +111,12 @@ function buildResumeUserMessage(briefing, conversation) {
 
 /** Update session metadata status */
 function updateSessionStatus(sessionDir, status) {
-  const metaPath = SessionPaths.metadataFile(sessionDir);
-  const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+  const meta = JSON.parse(readContainedSessionFile(sessionDir, 'metadata.json'));
   meta.status = status;
   if (status === 'running') {
     meta.resumedAt = new Date().toISOString();
   }
-  fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2));
+  writeContainedSessionFile(sessionDir, 'metadata.json', JSON.stringify(meta, null, 2), { mode: 0o600 });
   return meta;
 }
 

--- a/src/sidecar/resume.js
+++ b/src/sidecar/resume.js
@@ -17,6 +17,10 @@ const {
 const { acquireLock, releaseLock } = require('../utils/session-lock');
 const { runHeadless } = require('../headless');
 const { logger } = require('../utils/logger');
+const {
+  validateSidecarSessionDir,
+  validateSidecarSessionMetadata
+} = require('../utils/sidecar-boundaries');
 
 /** Load session metadata from session directory */
 function loadSessionMetadata(sessionDir) {
@@ -117,13 +121,11 @@ async function resumeSidecar(options) {
     mcp, mcpConfig, client, noMcp, excludeMcp
   } = options;
 
-  const sessionDir = SessionPaths.sessionDir(project, taskId);
-  if (!fs.existsSync(sessionDir)) {
-    throw new Error(`Session ${taskId} not found`);
-  }
+  const sessionDir = validateSidecarSessionDir(project, taskId);
 
   // Load previous session data
-  const metadata = loadSessionMetadata(sessionDir);
+  const metadata = validateSidecarSessionMetadata(loadSessionMetadata(sessionDir), project);
+  const effectiveProject = metadata.projectDir;
   const systemPrompt = loadInitialContext(sessionDir);
 
   // Dead-process detection: log if the previous process is no longer alive
@@ -143,7 +145,7 @@ async function resumeSidecar(options) {
     logger.info('Resuming session', { taskId, model: metadata.model, briefing: metadata.briefing });
 
     // Check for file drift
-    const drift = checkFileDrift(metadata, project);
+    const drift = checkFileDrift(metadata, effectiveProject);
     let resumePrompt = systemPrompt;
 
     if (drift.hasChanges) {
@@ -171,7 +173,7 @@ async function resumeSidecar(options) {
       const userMessage = buildResumeUserMessage(metadata.briefing || '', existingConversation);
       const result = await runHeadless(
         metadata.model, resumePrompt, userMessage,
-        taskId, project, timeout * 60 * 1000, effectiveAgent, { mcp: mcpServers }
+        taskId, effectiveProject, timeout * 60 * 1000, effectiveAgent, { mcp: mcpServers }
       );
       summary = result.summary || '## Sidecar Results: No Output\n\nResumed session completed without summary.';
 
@@ -182,7 +184,7 @@ async function resumeSidecar(options) {
 
       const result = await runInteractive(
         metadata.model, resumePrompt, metadata.briefing || '',
-        taskId, project,
+        taskId, effectiveProject,
         {
           agent: effectiveAgent,
           isResume: true,
@@ -199,7 +201,7 @@ async function resumeSidecar(options) {
     outputSummary(summary);
 
     // Finalize session (use updatedMetadata which has resumedAt)
-    finalizeSession(sessionDir, summary, project, updatedMetadata);
+    finalizeSession(sessionDir, summary, effectiveProject, updatedMetadata);
   } finally {
     if (heartbeat) { heartbeat.stop(); }
     releaseLock(sessionDir);

--- a/src/sidecar/session-utils.js
+++ b/src/sidecar/session-utils.js
@@ -8,6 +8,7 @@ const path = require('path');
 
 const { detectConflicts, formatConflictWarning } = require('../conflict');
 const { logger } = require('../utils/logger');
+const { writeContainedSessionFile } = require('../utils/sidecar-session-boundaries');
 
 /** Standard heartbeat interval in milliseconds */
 const HEARTBEAT_INTERVAL = 15000;
@@ -53,8 +54,6 @@ function saveInitialContext(sessionDir, systemPrompt, userMessage) {
 
 /** Finalize session - detect conflicts, save summary, update metadata */
 function finalizeSession(sessionDir, summary, project, metadata) {
-  const metaPath = SessionPaths.metadataFile(sessionDir);
-
   // Detect file conflicts
   const conflicts = detectConflicts(
     { written: metadata.filesWritten },
@@ -69,12 +68,12 @@ function finalizeSession(sessionDir, summary, project, metadata) {
   }
 
   // Save summary
-  fs.writeFileSync(SessionPaths.summaryFile(sessionDir), summary, { mode: 0o600 });
+  writeContainedSessionFile(sessionDir, 'summary.md', summary, { mode: 0o600 });
 
   // Update metadata to complete
   metadata.status = 'complete';
   metadata.completedAt = new Date().toISOString();
-  fs.writeFileSync(metaPath, JSON.stringify(metadata, null, 2), { mode: 0o600 });
+  writeContainedSessionFile(sessionDir, 'metadata.json', JSON.stringify(metadata, null, 2), { mode: 0o600 });
 
   logger.info('Session complete', { taskId: metadata.taskId });
 }

--- a/src/sidecar/session-utils.js
+++ b/src/sidecar/session-utils.js
@@ -3,7 +3,6 @@
  * Consolidates duplicated code from start.js, resume.js, continue.js
  */
 
-const fs = require('fs');
 const path = require('path');
 
 const { detectConflicts, formatConflictWarning } = require('../conflict');
@@ -49,7 +48,7 @@ const SessionPaths = {
 /** Save system prompt and user message to initial_context.md */
 function saveInitialContext(sessionDir, systemPrompt, userMessage) {
   const content = `# System Prompt\n\n${systemPrompt}\n\n# User Message (Task)\n\n${userMessage}`;
-  fs.writeFileSync(SessionPaths.contextFile(sessionDir), content, { mode: 0o600 });
+  writeContainedSessionFile(sessionDir, 'initial_context.md', content, { mode: 0o600 });
 }
 
 /** Finalize session - detect conflicts, save summary, update metadata */

--- a/src/sidecar/setup-window.js
+++ b/src/sidecar/setup-window.js
@@ -10,6 +10,7 @@ const { spawn } = require('child_process');
 const path = require('path');
 const { logger } = require('../utils/logger');
 const { getElectronPath } = require('./interactive');
+const { buildChildProcessEnv } = require('../utils/sidecar-env');
 
 /**
  * Launch the Electron setup window for API key entry
@@ -24,10 +25,9 @@ function launchSetupWindow() {
     }
     const mainPath = path.join(__dirname, '..', '..', 'electron', 'main.js');
 
-    const env = {
-      ...process.env,
+    const env = buildChildProcessEnv({
       SIDECAR_MODE: 'setup'
-    };
+    });
 
     const debugPort = process.env.SIDECAR_DEBUG_PORT;
     const args = debugPort

--- a/src/sidecar/start.js
+++ b/src/sidecar/start.js
@@ -5,6 +5,7 @@
 
 const crypto = require('crypto');
 const fs = require('fs');
+const path = require('path');
 
 const { buildContext } = require('./context-builder');
 const {
@@ -23,6 +24,11 @@ const { acquireLock, releaseLock } = require('../utils/session-lock');
 const { loadMcpConfig, parseMcpSpec } = require('../opencode-client');
 const { mapAgentToOpenCode } = require('../utils/agent-mapping');
 const { discoverParentMcps } = require('../utils/mcp-discovery');
+const {
+  assertContextBinding,
+  defaultIncludeContext,
+  validateProjectPath
+} = require('../utils/sidecar-boundaries');
 
 /** Generate a unique 8-character hex task ID */
 function generateTaskId() {
@@ -146,13 +152,13 @@ async function startSidecar(options) {
     cwd, project = process.cwd(), contextTurns = 50, contextSince,
     contextMaxTokens = 80000, noUi, headless = false, timeout = 15,
     agent, mcp, mcpConfig, summaryLength = 'normal', thinking,
-    client, sessionDir, noMcp, excludeMcp, opencodePort, coworkProcess, includeContext = true,
+    client, sessionDir, noMcp, excludeMcp, opencodePort, coworkProcess, includeContext = defaultIncludeContext(),
     position = 'right'
   } = options;
 
   const effectivePrompt = prompt || briefing;
   const effectiveSession = sessionId || session;
-  const effectiveProject = cwd || project;
+  const effectiveProject = validateProjectPath(path.resolve(cwd || project), { cwd: process.cwd() });
   const effectiveHeadless = noUi !== undefined ? noUi : headless;
   const mcpServers = buildMcpConfig({ mcp, mcpConfig, clientType: client, noMcp, excludeMcp });
   const taskId = options.taskId || generateTaskId();
@@ -160,9 +166,19 @@ async function startSidecar(options) {
 
   logger.info('Starting task', { taskId, model, mode: effectiveHeadless ? 'headless' : 'interactive' });
 
-  const context = includeContext !== false
-    ? buildContext(effectiveProject, effectiveSession, { contextTurns, contextSince, contextMaxTokens, sessionDir, client, coworkProcess })
-    : '[Context excluded by caller - briefing is self-contained]';
+  let context = '[Context excluded by caller - briefing is self-contained]';
+  if (includeContext === true) {
+    assertContextBinding({ sessionId, session, sessionDir, coworkProcess, client });
+    context = buildContext(effectiveProject, effectiveSession, {
+      contextTurns,
+      contextSince,
+      contextMaxTokens,
+      sessionDir,
+      client,
+      coworkProcess,
+      parentProject: effectiveProject
+    });
+  }
   const { system: systemPrompt, userMessage } = buildPrompts(
     effectivePrompt, context, effectiveProject, effectiveHeadless, agent, summaryLength, client
   );

--- a/src/sidecar/start.js
+++ b/src/sidecar/start.js
@@ -176,7 +176,8 @@ async function startSidecar(options) {
       sessionDir,
       client,
       coworkProcess,
-      parentProject: effectiveProject
+      parentProject: effectiveProject,
+      exactSession: true
     });
   }
   const { system: systemPrompt, userMessage } = buildPrompts(

--- a/src/sidecar/start.js
+++ b/src/sidecar/start.js
@@ -4,12 +4,10 @@
  */
 
 const crypto = require('crypto');
-const fs = require('fs');
 const path = require('path');
 
 const { buildContext } = require('./context-builder');
 const {
-  SessionPaths,
   saveInitialContext,
   finalizeSession,
   outputSummary,
@@ -29,6 +27,11 @@ const {
   defaultIncludeContext,
   validateProjectPath
 } = require('../utils/sidecar-boundaries');
+const {
+  ensureSidecarSessionDir,
+  readContainedSessionFile,
+  writeContainedSessionFile
+} = require('../utils/sidecar-session-boundaries');
 
 /** Generate a unique 8-character hex task ID */
 function generateTaskId() {
@@ -39,21 +42,20 @@ function generateTaskId() {
 function createSessionMetadata(taskId, project, options) {
   const { model, prompt, briefing, noUi, headless, agent, thinking } = options;
 
-  const sessionDir = SessionPaths.sessionDir(project, taskId);
-  fs.mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
+  const sessionDir = ensureSidecarSessionDir(project, taskId);
 
   const effectiveBriefing = prompt || briefing;
   const isHeadless = noUi !== undefined ? noUi : headless;
 
   // Preserve fields from existing metadata (e.g., pid written by MCP handler)
-  const metaPath = SessionPaths.metadataFile(sessionDir);
   let existing = {};
-  if (fs.existsSync(metaPath)) {
-    try {
-      existing = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
-    } catch {
-      // ignore corrupt metadata
+  try {
+    const metadataText = readContainedSessionFile(sessionDir, 'metadata.json', { optional: true });
+    if (metadataText !== null) {
+      existing = JSON.parse(metadataText);
     }
+  } catch {
+    // ignore corrupt metadata
   }
 
   const metadata = {
@@ -70,7 +72,7 @@ function createSessionMetadata(taskId, project, options) {
     createdAt: existing.createdAt || new Date().toISOString()
   };
 
-  fs.writeFileSync(metaPath, JSON.stringify(metadata, null, 2), { mode: 0o600 });
+  writeContainedSessionFile(sessionDir, 'metadata.json', JSON.stringify(metadata, null, 2), { mode: 0o600 });
 
   return sessionDir;
 }
@@ -219,13 +221,12 @@ async function startSidecar(options) {
   }
 
   outputSummary(summary);
-  const metaPath = SessionPaths.metadataFile(sessDir);
-  const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+  const meta = JSON.parse(readContainedSessionFile(sessDir, 'metadata.json'));
 
   // Persist OpenCode session ID for resume capability
   if (result && result.opencodeSessionId) {
     meta.opencodeSessionId = result.opencodeSessionId;
-    fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), { mode: 0o600 });
+    writeContainedSessionFile(sessDir, 'metadata.json', JSON.stringify(meta, null, 2), { mode: 0o600 });
   }
 
   // Mark error results as 'error' instead of 'complete'
@@ -233,7 +234,7 @@ async function startSidecar(options) {
     meta.status = 'error';
     meta.reason = result.error;
     meta.completedAt = new Date().toISOString();
-    fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2), { mode: 0o600 });
+    writeContainedSessionFile(sessDir, 'metadata.json', JSON.stringify(meta, null, 2), { mode: 0o600 });
     logger.error('Session completed with error', { taskId, error: result.error });
   } else {
     finalizeSession(sessDir, summary, effectiveProject, meta);

--- a/src/subagents/codex-event-normalizer.js
+++ b/src/subagents/codex-event-normalizer.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * Parse a single Codex JSONL line.
+ *
+ * @param {string} line
+ * @returns {object|null}
+ */
+function parseCodexJsonLine(line) {
+  if (!line || !line.trim()) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(line);
+  } catch (error) {
+    throw new Error(`Invalid Codex JSON line: ${error.message}`);
+  }
+}
+
+/**
+ * Normalize observed Codex event shapes into Sidecar-style records.
+ *
+ * @param {object} event
+ * @returns {object|null}
+ */
+function normalizeCodexEvent(event) {
+  if (!event || event.type !== 'item.completed' || !event.item) {
+    return null;
+  }
+
+  if (event.item.type === 'agent_message' && event.item.text) {
+    return {
+      kind: 'assistant_text',
+      content: event.item.text
+    };
+  }
+
+  if (event.item.type === 'command_execution' && event.item.command) {
+    return {
+      kind: 'tool_use',
+      toolCall: {
+        name: 'command_execution',
+        input: {
+          command: event.item.command,
+          exitCode: event.item.exit_code,
+          status: event.item.status
+        }
+      }
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Extract a final summary string from an event, if present.
+ *
+ * @param {object} event
+ * @returns {string|null}
+ */
+function getFinalSummary(event) {
+  const normalized = normalizeCodexEvent(event);
+  if (normalized && normalized.kind === 'assistant_text') {
+    return normalized.content;
+  }
+  return null;
+}
+
+module.exports = {
+  parseCodexJsonLine,
+  normalizeCodexEvent,
+  getFinalSummary
+};

--- a/src/subagents/codex-runner.js
+++ b/src/subagents/codex-runner.js
@@ -68,7 +68,7 @@ function addRolePreamble(agentType, briefing) {
  */
 function assertCodexAvailable() {
   return new Promise((resolve, reject) => {
-    execFile('codex', ['exec', '--help'], (error) => {
+    execFile('codex', ['exec', '--help'], { env: buildChildProcessEnv() }, (error) => {
       if (error) {
         reject(error);
         return;

--- a/src/subagents/codex-runner.js
+++ b/src/subagents/codex-runner.js
@@ -7,10 +7,13 @@ const {
   createSubagentSession,
   updateSubagentSession,
   saveSubagentSummary,
+  getSession,
+  getSessionDir,
   getSubagentDir,
   appendSubagentConversation
 } = require('../session-manager');
 const { writeProgress } = require('../sidecar/progress');
+const { validateSubagentLaunchProject } = require('../utils/sidecar-boundaries');
 const {
   parseCodexJsonLine,
   normalizeCodexEvent
@@ -201,18 +204,7 @@ function monitorCodexSubagent({
   });
 }
 
-/**
- * Start a Codex-backed subagent and return once the subprocess is running.
- *
- * @param {object} options
- * @param {string} options.projectDir
- * @param {string} options.parentTaskId
- * @param {string} options.subagentId
- * @param {string} options.briefing
- * @param {string} options.agentType
- * @param {string} [options.model]
- * @returns {Promise<{subagentDir: string, pid: number|null, completion: Promise<void>}>}
- */
+/** Start a Codex-backed subagent and return once the subprocess is running. */
 async function startCodexSubagent({
   projectDir,
   parentTaskId,
@@ -223,32 +215,40 @@ async function startCodexSubagent({
 }) {
   await assertCodexAvailable();
 
+  const validatedProjectDir = validateSubagentLaunchProject({
+    projectDir,
+    parentTaskId,
+    getSession,
+    getSessionDir
+  });
+
   const sandboxMode = resolveSandboxMode(agentType);
   const fullBriefing = addRolePreamble(agentType, briefing);
 
-  createSubagentSession(projectDir, parentTaskId, subagentId, {
+  createSubagentSession(validatedProjectDir, parentTaskId, subagentId, {
     agentType,
     briefing,
     backend: 'codex',
-    sandboxMode
+    sandboxMode,
+    projectDir: validatedProjectDir
   });
 
-  const subagentDir = getSubagentDir(projectDir, parentTaskId, subagentId);
+  const subagentDir = getSubagentDir(validatedProjectDir, parentTaskId, subagentId);
   writeProgress(subagentDir, 'prompt_sent', {
     stageLabel: 'Launching Codex subagent...'
   });
 
-  const args = ['exec', '--json', '--sandbox', sandboxMode, '-C', projectDir, '-'];
+  const args = ['exec', '--json', '--sandbox', sandboxMode, '-C', validatedProjectDir, '-'];
   if (model) {
     args.splice(2, 0, '--model', model);
   }
 
   const child = spawn('codex', args, {
-    cwd: projectDir,
+    cwd: validatedProjectDir,
     stdio: ['pipe', 'pipe', 'pipe']
   });
 
-  updateSubagentSession(projectDir, parentTaskId, subagentId, {
+  updateSubagentSession(validatedProjectDir, parentTaskId, subagentId, {
     backend: 'codex',
     sandboxMode,
     pid: child.pid || null,
@@ -261,7 +261,7 @@ async function startCodexSubagent({
     subagentDir,
     pid: child.pid || null,
     completion: monitorCodexSubagent({
-      projectDir,
+      projectDir: validatedProjectDir,
       parentTaskId,
       subagentId,
       subagentDir,

--- a/src/subagents/codex-runner.js
+++ b/src/subagents/codex-runner.js
@@ -13,7 +13,7 @@ const {
   appendSubagentConversation
 } = require('../session-manager');
 const { writeProgress } = require('../sidecar/progress');
-const { validateSubagentLaunchProject } = require('../utils/sidecar-boundaries');
+const { buildChildProcessEnv, validateSubagentLaunchProject } = require('../utils/sidecar-boundaries');
 const {
   parseCodexJsonLine,
   normalizeCodexEvent
@@ -245,7 +245,8 @@ async function startCodexSubagent({
 
   const child = spawn('codex', args, {
     cwd: validatedProjectDir,
-    stdio: ['pipe', 'pipe', 'pipe']
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: buildChildProcessEnv()
   });
 
   updateSubagentSession(validatedProjectDir, parentTaskId, subagentId, {

--- a/src/subagents/codex-runner.js
+++ b/src/subagents/codex-runner.js
@@ -1,0 +1,296 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execFile, spawn } = require('child_process');
+const {
+  createSubagentSession,
+  updateSubagentSession,
+  saveSubagentSummary,
+  getSubagentDir,
+  appendSubagentConversation
+} = require('../session-manager');
+const { writeProgress } = require('../sidecar/progress');
+const {
+  parseCodexJsonLine,
+  normalizeCodexEvent
+} = require('./codex-event-normalizer');
+
+/**
+ * Map Sidecar agent types onto Codex sandbox modes.
+ *
+ * @param {string} agentType
+ * @returns {string}
+ */
+function resolveSandboxMode(agentType) {
+  if (agentType === 'plan' || agentType === 'explore') {
+    return 'read-only';
+  }
+  if (agentType === 'build' || agentType === 'general') {
+    return 'workspace-write';
+  }
+  if (agentType === 'chat') {
+    throw new Error('Codex backend does not support interactive chat mode');
+  }
+  throw new Error(`Unsupported Codex subagent type: ${agentType}`);
+}
+
+/**
+ * Add a short role preamble so Codex behaves closer to OpenCode semantics.
+ *
+ * @param {string} agentType
+ * @param {string} briefing
+ * @returns {string}
+ */
+function addRolePreamble(agentType, briefing) {
+  const preambles = {
+    plan: 'ROLE: Plan. Analyze the task, propose an approach, and do not modify files.',
+    explore: 'ROLE: Explore. Inspect the codebase, summarize findings, and stay read-only.',
+    build: 'ROLE: Build. Complete the task directly, make necessary changes, and report what changed.',
+    general: 'ROLE: General. Execute the task with full workspace access and summarize outcomes.'
+  };
+
+  const preamble = preambles[agentType];
+  if (!preamble) {
+    throw new Error(`Unsupported Codex subagent type: ${agentType}`);
+  }
+
+  return `${preamble}\n\n${briefing}`;
+}
+
+/**
+ * Check that the local Codex CLI is available.
+ *
+ * @returns {Promise<void>}
+ */
+function assertCodexAvailable() {
+  return new Promise((resolve, reject) => {
+    execFile('codex', ['exec', '--help'], (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+/**
+ * Attach stream handlers and finalize a spawned Codex subagent.
+ *
+ * @param {object} options
+ * @param {string} options.projectDir
+ * @param {string} options.parentTaskId
+ * @param {string} options.subagentId
+ * @param {string} options.subagentDir
+ * @param {import('child_process').ChildProcess} options.child
+ * @returns {Promise<void>}
+ */
+function monitorCodexSubagent({
+  projectDir,
+  parentTaskId,
+  subagentId,
+  subagentDir,
+  child
+}) {
+  const stderrPath = path.join(subagentDir, 'codex-stderr.log');
+
+  return new Promise((resolve) => {
+    let stderr = '';
+    let stdoutBuffer = '';
+    let finalSummary = null;
+
+    child.stdout.on('data', (chunk) => {
+      stdoutBuffer += String(chunk);
+
+      const lines = stdoutBuffer.split('\n');
+      stdoutBuffer = lines.pop();
+
+      for (const line of lines) {
+        const event = parseCodexJsonLine(line);
+        if (!event) {
+          continue;
+        }
+
+        const normalized = normalizeCodexEvent(event);
+        if (!normalized) {
+          continue;
+        }
+
+        if (normalized.kind === 'assistant_text') {
+          appendSubagentConversation(projectDir, parentTaskId, subagentId, {
+            role: 'assistant',
+            content: normalized.content
+          });
+          finalSummary = normalized.content;
+          writeProgress(subagentDir, 'receiving', {
+            stageLabel: 'Codex is generating a response...'
+          });
+        }
+
+        if (normalized.kind === 'tool_use') {
+          appendSubagentConversation(projectDir, parentTaskId, subagentId, {
+            role: 'assistant',
+            type: 'tool_use',
+            toolCall: normalized.toolCall
+          });
+          writeProgress(subagentDir, 'receiving', {
+            latestTool: normalized.toolCall.name,
+            stageLabel: `Calling tool: ${normalized.toolCall.name}`
+          });
+        }
+      }
+    });
+
+    child.stderr.on('data', (chunk) => {
+      const text = String(chunk);
+      stderr += text;
+      fs.appendFileSync(stderrPath, text, { mode: 0o600 });
+    });
+
+    child.on('error', (error) => {
+      updateSubagentSession(projectDir, parentTaskId, subagentId, {
+        status: 'error',
+        exitCode: null,
+        stderrPath,
+        reason: error.message,
+        completedAt: new Date().toISOString(),
+        pid: null
+      });
+      resolve();
+    });
+
+    child.on('close', (code) => {
+      if (stdoutBuffer.trim()) {
+        const event = parseCodexJsonLine(stdoutBuffer);
+        const normalized = normalizeCodexEvent(event);
+        if (normalized && normalized.kind === 'assistant_text') {
+          appendSubagentConversation(projectDir, parentTaskId, subagentId, {
+            role: 'assistant',
+            content: normalized.content
+          });
+          finalSummary = normalized.content;
+        }
+      }
+
+      if (code === 0 && finalSummary) {
+        saveSubagentSummary(projectDir, parentTaskId, subagentId, finalSummary);
+        updateSubagentSession(projectDir, parentTaskId, subagentId, {
+          backend: 'codex',
+          exitCode: 0,
+          stderrPath,
+          pid: null
+        });
+        writeProgress(subagentDir, 'complete', {
+          stageLabel: 'Complete'
+        });
+        resolve();
+        return;
+      }
+
+      updateSubagentSession(projectDir, parentTaskId, subagentId, {
+        status: 'error',
+        exitCode: code,
+        stderrPath,
+        reason: stderr.trim() || `codex exited with code ${code}`,
+        completedAt: new Date().toISOString(),
+        pid: null
+      });
+      resolve();
+    });
+  });
+}
+
+/**
+ * Start a Codex-backed subagent and return once the subprocess is running.
+ *
+ * @param {object} options
+ * @param {string} options.projectDir
+ * @param {string} options.parentTaskId
+ * @param {string} options.subagentId
+ * @param {string} options.briefing
+ * @param {string} options.agentType
+ * @param {string} [options.model]
+ * @returns {Promise<{subagentDir: string, pid: number|null, completion: Promise<void>}>}
+ */
+async function startCodexSubagent({
+  projectDir,
+  parentTaskId,
+  subagentId,
+  briefing,
+  agentType,
+  model,
+}) {
+  await assertCodexAvailable();
+
+  const sandboxMode = resolveSandboxMode(agentType);
+  const fullBriefing = addRolePreamble(agentType, briefing);
+
+  createSubagentSession(projectDir, parentTaskId, subagentId, {
+    agentType,
+    briefing,
+    backend: 'codex',
+    sandboxMode
+  });
+
+  const subagentDir = getSubagentDir(projectDir, parentTaskId, subagentId);
+  writeProgress(subagentDir, 'prompt_sent', {
+    stageLabel: 'Launching Codex subagent...'
+  });
+
+  const args = ['exec', '--json', '--sandbox', sandboxMode, '-C', projectDir, '-'];
+  if (model) {
+    args.splice(2, 0, '--model', model);
+  }
+
+  const child = spawn('codex', args, {
+    cwd: projectDir,
+    stdio: ['pipe', 'pipe', 'pipe']
+  });
+
+  updateSubagentSession(projectDir, parentTaskId, subagentId, {
+    backend: 'codex',
+    sandboxMode,
+    pid: child.pid || null,
+    status: 'running'
+  });
+
+  child.stdin.end(fullBriefing);
+
+  return {
+    subagentDir,
+    pid: child.pid || null,
+    completion: monitorCodexSubagent({
+      projectDir,
+      parentTaskId,
+      subagentId,
+      subagentDir,
+      child
+    })
+  };
+}
+
+/**
+ * Run a Codex-backed subagent to completion.
+ *
+ * @param {object} options
+ * @param {string} options.projectDir
+ * @param {string} options.parentTaskId
+ * @param {string} options.subagentId
+ * @param {string} options.briefing
+ * @param {string} options.agentType
+ * @param {string} [options.model]
+ * @returns {Promise<void>}
+ */
+async function runCodexSubagent(options) {
+  const run = await startCodexSubagent(options);
+  await run.completion;
+}
+
+module.exports = {
+  runCodexSubagent,
+  startCodexSubagent,
+  resolveSandboxMode,
+  addRolePreamble,
+  assertCodexAvailable
+};

--- a/src/subagents/codex-runner.js
+++ b/src/subagents/codex-runner.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const fs = require('fs');
 const path = require('path');
 const { execFile, spawn } = require('child_process');
 const {
@@ -9,11 +8,11 @@ const {
   saveSubagentSummary,
   getSession,
   getSessionDir,
-  getSubagentDir,
   appendSubagentConversation
 } = require('../session-manager');
 const { writeProgress } = require('../sidecar/progress');
 const { buildChildProcessEnv, validateSubagentLaunchProject } = require('../utils/sidecar-boundaries');
+const { appendContainedSessionFile } = require('../utils/sidecar-session-boundaries');
 const {
   parseCodexJsonLine,
   normalizeCodexEvent
@@ -96,12 +95,14 @@ function monitorCodexSubagent({
   subagentDir,
   child
 }) {
-  const stderrPath = path.join(subagentDir, 'codex-stderr.log');
+  const stderrFilename = 'codex-stderr.log';
+  const stderrPath = path.join(subagentDir, stderrFilename);
 
   return new Promise((resolve) => {
     let stderr = '';
     let stdoutBuffer = '';
     let finalSummary = null;
+    let stderrWriteError = null;
 
     child.stdout.on('data', (chunk) => {
       stdoutBuffer += String(chunk);
@@ -148,7 +149,11 @@ function monitorCodexSubagent({
     child.stderr.on('data', (chunk) => {
       const text = String(chunk);
       stderr += text;
-      fs.appendFileSync(stderrPath, text, { mode: 0o600 });
+      try {
+        appendContainedSessionFile(subagentDir, stderrFilename, text, { mode: 0o600 });
+      } catch (err) {
+        stderrWriteError = err;
+      }
     });
 
     child.on('error', (error) => {
@@ -195,7 +200,7 @@ function monitorCodexSubagent({
         status: 'error',
         exitCode: code,
         stderrPath,
-        reason: stderr.trim() || `codex exited with code ${code}`,
+        reason: stderr.trim() || (stderrWriteError && stderrWriteError.message) || `codex exited with code ${code}`,
         completedAt: new Date().toISOString(),
         pid: null
       });
@@ -225,15 +230,13 @@ async function startCodexSubagent({
   const sandboxMode = resolveSandboxMode(agentType);
   const fullBriefing = addRolePreamble(agentType, briefing);
 
-  createSubagentSession(validatedProjectDir, parentTaskId, subagentId, {
+  const subagentDir = createSubagentSession(validatedProjectDir, parentTaskId, subagentId, {
     agentType,
     briefing,
     backend: 'codex',
     sandboxMode,
     projectDir: validatedProjectDir
   });
-
-  const subagentDir = getSubagentDir(validatedProjectDir, parentTaskId, subagentId);
   writeProgress(subagentDir, 'prompt_sent', {
     stageLabel: 'Launching Codex subagent...'
   });

--- a/src/utils/api-key-store.js
+++ b/src/utils/api-key-store.js
@@ -33,6 +33,19 @@ function getEnvPath() {
   return path.join(homeDir, '.config', 'sidecar', '.env');
 }
 
+/** Ensure the secret env directory is owner-only. */
+function ensureSecureEnvDir(envDir) {
+  fs.mkdirSync(envDir, { recursive: true, mode: 0o700 });
+  fs.chmodSync(envDir, 0o700);
+}
+
+/** Write the secret env file with owner-only permissions. */
+function writeSecureEnvFile(envPath, content) {
+  ensureSecureEnvDir(path.dirname(envPath));
+  fs.writeFileSync(envPath, content, { mode: 0o600 });
+  fs.chmodSync(envPath, 0o600);
+}
+
 /** Parse a .env file into a key-value map (comments/blanks excluded) */
 function parseEnvContent(content) {
   const entries = new Map();
@@ -60,7 +73,7 @@ function migrateEnvFileKey(envPath, oldName, newName) {
     const re = new RegExp(`^${oldName}=`, 'm');
     const updated = content.replace(re, `${newName}=`);
     if (updated !== content) {
-      fs.writeFileSync(envPath, updated, { mode: 0o600 });
+      writeSecureEnvFile(envPath, updated);
     }
   } catch (_err) {
     // Best effort
@@ -153,7 +166,7 @@ function saveApiKey(provider, key) {
 
   const envPath = getEnvPath();
   const envDir = path.dirname(envPath);
-  fs.mkdirSync(envDir, { recursive: true });
+  ensureSecureEnvDir(envDir);
 
   // Read existing .env content, preserving comments and other lines
   let lines = [];
@@ -186,7 +199,7 @@ function saveApiKey(provider, key) {
 
   // Write with trailing newline
   const output = lines.join('\n') + '\n';
-  fs.writeFileSync(envPath, output, { mode: 0o600 });
+  writeSecureEnvFile(envPath, output);
 
   // Also set process.env so the key is immediately available
   process.env[envVar] = key;
@@ -219,7 +232,7 @@ function removeApiKey(provider) {
     }
 
     const output = lines.length > 0 ? lines.join('\n') + '\n' : '';
-    fs.writeFileSync(envPath, output, { mode: 0o600 });
+    writeSecureEnvFile(envPath, output);
   } catch (_err) {
     // Ignore
   }

--- a/src/utils/sidecar-boundaries.js
+++ b/src/utils/sidecar-boundaries.js
@@ -6,6 +6,7 @@ const path = require('path');
 const { buildChildProcessEnv } = require('./sidecar-env');
 const {
   validateSidecarSessionsRoot,
+  ensureSidecarSessionDir,
   validateSidecarSessionDir,
   validateSidecarSubagentSessionDir,
   validateSidecarSessionMetadata,
@@ -279,6 +280,7 @@ module.exports = {
   validateSessionDir,
   validateSubagentParent,
   validateSidecarSessionsRoot,
+  ensureSidecarSessionDir,
   validateSidecarSessionDir,
   validateSidecarSubagentSessionDir,
   validateSidecarSessionMetadata,

--- a/src/utils/sidecar-boundaries.js
+++ b/src/utils/sidecar-boundaries.js
@@ -5,9 +5,13 @@ const os = require('os');
 const path = require('path');
 const { buildChildProcessEnv } = require('./sidecar-env');
 const {
+  validateSidecarSessionsRoot,
   validateSidecarSessionDir,
+  validateSidecarSubagentSessionDir,
   validateSidecarSessionMetadata,
-  readContainedSessionFile
+  resolveContainedSessionFile,
+  readContainedSessionFile,
+  writeContainedSessionFile
 } = require('./sidecar-session-boundaries');
 const { validateTaskId } = require('./validators');
 
@@ -273,9 +277,13 @@ module.exports = {
   validateProjectPath,
   validateSessionDir,
   validateSubagentParent,
+  validateSidecarSessionsRoot,
   validateSidecarSessionDir,
+  validateSidecarSubagentSessionDir,
   validateSidecarSessionMetadata,
+  resolveContainedSessionFile,
   readContainedSessionFile,
+  writeContainedSessionFile,
   defaultIncludeContext,
   hasContextBinding,
   assertContextBinding,

--- a/src/utils/sidecar-boundaries.js
+++ b/src/utils/sidecar-boundaries.js
@@ -3,6 +3,11 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { buildChildProcessEnv } = require('./sidecar-env');
+const {
+  validateSidecarSessionDir,
+  validateSidecarSessionMetadata
+} = require('./sidecar-session-boundaries');
 const { validateTaskId } = require('./validators');
 
 function realpathSync(targetPath) {
@@ -74,7 +79,17 @@ function parseAllowedRoots(value) {
 
 function restrictedRootSet() {
   const roots = new Set();
-  for (const candidate of ['/', os.homedir(), os.tmpdir(), '/tmp']) {
+  for (const candidate of [
+    '/',
+    os.homedir(),
+    os.tmpdir(),
+    '/tmp',
+    '/Users',
+    '/Volumes',
+    '/System',
+    '/System/Volumes',
+    '/System/Volumes/Data'
+  ]) {
     try {
       roots.add(realpathSync(candidate));
     } catch {
@@ -109,6 +124,11 @@ function validateProjectPath(project, options = {}) {
   const configuredRoots = options.allowedRoots !== undefined
     ? parseAllowedRoots(options.allowedRoots)
     : parseAllowedRoots(process.env.SIDECAR_ALLOWED_ROOTS);
+  for (const root of configuredRoots) {
+    if (isRestrictedRoot(root)) {
+      throw new Error(`Allowed root is unsafe by default: ${root}`);
+    }
+  }
   const allowedRoots = isRestrictedRoot(canonicalCwd)
     ? configuredRoots
     : [canonicalCwd, ...configuredRoots];
@@ -182,7 +202,18 @@ function resolveExactSessionFile(sessionDir, session) {
   if (!fs.existsSync(sessionPath)) {
     throw new Error(`Exact session ${session} not found`);
   }
-  return { path: sessionPath, method: 'explicit' };
+
+  const canonicalSessionDir = canonicalizeExistingDir(path.resolve(sessionDir), 'Session directory');
+  const canonicalSessionPath = realpathSync(sessionPath);
+  if (!isPathInside(canonicalSessionDir, canonicalSessionPath)) {
+    throw new Error(`Exact session file is outside the session directory: ${canonicalSessionPath}`);
+  }
+  const stat = fs.statSync(canonicalSessionPath);
+  if (!stat.isFile()) {
+    throw new Error(`Exact session target is not a regular file: ${sessionPath}`);
+  }
+
+  return { path: canonicalSessionPath, method: 'explicit' };
 }
 
 function hasContextBinding(options = {}) {
@@ -240,6 +271,8 @@ module.exports = {
   validateProjectPath,
   validateSessionDir,
   validateSubagentParent,
+  validateSidecarSessionDir,
+  validateSidecarSessionMetadata,
   defaultIncludeContext,
   hasContextBinding,
   assertContextBinding,
@@ -247,5 +280,6 @@ module.exports = {
   resolveExactSessionFile,
   resolveContextSessionScope,
   validateSubagentLaunchProject,
+  buildChildProcessEnv,
   isPathInside
 };

--- a/src/utils/sidecar-boundaries.js
+++ b/src/utils/sidecar-boundaries.js
@@ -6,7 +6,8 @@ const path = require('path');
 const { buildChildProcessEnv } = require('./sidecar-env');
 const {
   validateSidecarSessionDir,
-  validateSidecarSessionMetadata
+  validateSidecarSessionMetadata,
+  readContainedSessionFile
 } = require('./sidecar-session-boundaries');
 const { validateTaskId } = require('./validators');
 
@@ -254,6 +255,7 @@ function validateSubagentLaunchProject({ projectDir, parentTaskId, getSession, g
   if (!fs.existsSync(parentDir)) {
     throw new Error(`Parent session ${parentTaskId} not found`);
   }
+  validateSidecarSessionDir(validatedProjectDir, parentTaskId);
   const parentMetadata = getSession(validatedProjectDir, parentTaskId);
   if (!parentMetadata) {
     throw new Error(`Parent session ${parentTaskId} metadata not found`);
@@ -273,6 +275,7 @@ module.exports = {
   validateSubagentParent,
   validateSidecarSessionDir,
   validateSidecarSessionMetadata,
+  readContainedSessionFile,
   defaultIncludeContext,
   hasContextBinding,
   assertContextBinding,

--- a/src/utils/sidecar-boundaries.js
+++ b/src/utils/sidecar-boundaries.js
@@ -11,6 +11,7 @@ const {
   validateSidecarSessionMetadata,
   resolveContainedSessionFile,
   readContainedSessionFile,
+  openContainedSessionFileForWrite,
   writeContainedSessionFile
 } = require('./sidecar-session-boundaries');
 const { validateTaskId } = require('./validators');
@@ -283,6 +284,7 @@ module.exports = {
   validateSidecarSessionMetadata,
   resolveContainedSessionFile,
   readContainedSessionFile,
+  openContainedSessionFileForWrite,
   writeContainedSessionFile,
   defaultIncludeContext,
   hasContextBinding,

--- a/src/utils/sidecar-boundaries.js
+++ b/src/utils/sidecar-boundaries.js
@@ -1,0 +1,220 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { validateTaskId } = require('./validators');
+
+function realpathSync(targetPath) {
+  return fs.realpathSync.native
+    ? fs.realpathSync.native(targetPath)
+    : fs.realpathSync(targetPath);
+}
+
+function assertAbsolutePath(targetPath, label) {
+  if (!targetPath || typeof targetPath !== 'string') {
+    throw new Error(`${label} is required`);
+  }
+  if (targetPath.includes('\0')) {
+    throw new Error(`${label} cannot contain null bytes`);
+  }
+  if (!path.isAbsolute(targetPath)) {
+    throw new Error(`${label} must be an absolute path`);
+  }
+}
+
+function isPathInside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function canonicalizeExistingDir(targetPath, label) {
+  assertAbsolutePath(targetPath, label);
+  if (!fs.existsSync(targetPath)) {
+    throw new Error(`${label} does not exist: ${targetPath}`);
+  }
+  const canonical = realpathSync(targetPath);
+  const stat = fs.statSync(canonical);
+  if (!stat.isDirectory()) {
+    throw new Error(`${label} is not a directory: ${targetPath}`);
+  }
+  return canonical;
+}
+
+function canonicalizeContainingPath(targetPath, label) {
+  assertAbsolutePath(targetPath, label);
+
+  let current = path.resolve(targetPath);
+  const missingParts = [];
+  while (!fs.existsSync(current)) {
+    const next = path.dirname(current);
+    if (next === current) {
+      throw new Error(`${label} does not exist: ${targetPath}`);
+    }
+    missingParts.unshift(path.basename(current));
+    current = next;
+  }
+
+  const canonicalBase = realpathSync(current);
+  return missingParts.length > 0
+    ? path.join(canonicalBase, ...missingParts)
+    : canonicalBase;
+}
+
+function parseAllowedRoots(value) {
+  if (!value) {
+    return [];
+  }
+  const roots = Array.isArray(value)
+    ? value
+    : String(value).split(path.delimiter).filter(Boolean);
+
+  return roots.map((root) => canonicalizeExistingDir(root, 'Allowed root'));
+}
+
+function restrictedRootSet() {
+  const roots = new Set();
+  for (const candidate of ['/', os.homedir(), os.tmpdir(), '/tmp']) {
+    try {
+      roots.add(realpathSync(candidate));
+    } catch {
+      roots.add(path.resolve(candidate));
+    }
+  }
+  return roots;
+}
+
+function defaultIncludeContext() {
+  return false;
+}
+
+function validateProjectPath(project, options = {}) {
+  const cwd = options.cwd || process.cwd();
+  const canonicalCwd = canonicalizeExistingDir(path.resolve(cwd), 'Current working directory');
+  const requestedProject = path.resolve(project || canonicalCwd);
+  const canonicalProject = canonicalizeExistingDir(requestedProject, 'Project path');
+
+  if (process.env.SIDECAR_ALLOW_UNSAFE_PROJECT === '1' || options.allowUnsafe === true) {
+    return canonicalProject;
+  }
+
+  if (restrictedRootSet().has(canonicalProject)) {
+    throw new Error(`Project path is unsafe by default: ${canonicalProject}`);
+  }
+
+  const configuredRoots = options.allowedRoots !== undefined
+    ? parseAllowedRoots(options.allowedRoots)
+    : parseAllowedRoots(process.env.SIDECAR_ALLOWED_ROOTS);
+  const allowedRoots = [canonicalCwd, ...configuredRoots];
+
+  if (!allowedRoots.some((root) => isPathInside(root, canonicalProject))) {
+    throw new Error(`Project path is not allowed: ${canonicalProject}`);
+  }
+
+  return canonicalProject;
+}
+
+function validateSessionDir(sessionDir, projectRoot) {
+  const canonicalProjectRoot = canonicalizeExistingDir(path.resolve(projectRoot), 'Project root');
+  const canonicalSessionDir = canonicalizeContainingPath(path.resolve(sessionDir), 'Session directory');
+
+  if (!isPathInside(canonicalProjectRoot, canonicalSessionDir)) {
+    throw new Error(`Session directory is outside the project root: ${canonicalSessionDir}`);
+  }
+
+  return canonicalSessionDir;
+}
+
+function validateSubagentParent(metadata, projectRoot) {
+  if (!metadata || typeof metadata !== 'object') {
+    throw new Error('Parent session metadata is required');
+  }
+
+  const parentTaskId = metadata.parentTaskId || metadata.taskId;
+  const taskCheck = validateTaskId(parentTaskId);
+  if (!taskCheck.valid) {
+    throw new Error(taskCheck.error);
+  }
+
+  const metadataProject = metadata.projectDir || metadata.project || metadata.cwd;
+  if (!metadataProject) {
+    throw new Error('Parent session metadata is missing project binding');
+  }
+
+  const canonicalProjectRoot = canonicalizeExistingDir(path.resolve(projectRoot), 'Project root');
+  const canonicalMetadataProject = canonicalizeExistingDir(path.resolve(metadataProject), 'Parent project');
+  if (canonicalMetadataProject !== canonicalProjectRoot) {
+    throw new Error(`Parent session project does not match project root: ${canonicalMetadataProject}`);
+  }
+
+  return {
+    ...metadata,
+    projectDir: canonicalMetadataProject,
+    parentTaskId
+  };
+}
+
+function hasContextBinding(options = {}) {
+  return Boolean(
+    options.parentSession ||
+    options.sessionId ||
+    options.session ||
+    options.sessionDir ||
+    options.coworkProcess
+  );
+}
+
+function assertContextBinding(options = {}) {
+  if (!hasContextBinding(options)) {
+    throw new Error('includeContext requires parentSession, session, sessionDir, or coworkProcess');
+  }
+  if (options.client === 'cowork' && !options.sessionDir && !options.coworkProcess) {
+    throw new Error('Cowork context requires coworkProcess for exact session matching');
+  }
+}
+
+function resolveContextSessionScope({ project, parentProject, sessionDir, homeDir, getSessionDirectory }) {
+  const validatedProject = parentProject
+    ? validateProjectPath(path.resolve(project), { cwd: parentProject, allowedRoots: [parentProject] })
+    : project;
+  const resolvedSessionDir = sessionDir
+    ? validateSessionDir(path.resolve(sessionDir), validatedProject)
+    : getSessionDirectory(validatedProject, homeDir);
+
+  return { validatedProject, resolvedSessionDir };
+}
+
+function validateSubagentLaunchProject({ projectDir, parentTaskId, getSession, getSessionDir }) {
+  const validatedProjectDir = validateProjectPath(path.resolve(projectDir), {
+    cwd: path.resolve(projectDir),
+    allowedRoots: [path.resolve(projectDir)]
+  });
+  const parentDir = getSessionDir(validatedProjectDir, parentTaskId);
+  if (!fs.existsSync(parentDir)) {
+    throw new Error(`Parent session ${parentTaskId} not found`);
+  }
+  const parentMetadata = getSession(validatedProjectDir, parentTaskId) || {
+    taskId: parentTaskId,
+    projectDir: validatedProjectDir
+  };
+  validateSubagentParent({
+    ...parentMetadata,
+    taskId: parentMetadata.taskId || parentTaskId,
+    projectDir: parentMetadata.projectDir || parentMetadata.project || validatedProjectDir
+  }, validatedProjectDir);
+
+  return validatedProjectDir;
+}
+
+module.exports = {
+  parseAllowedRoots,
+  validateProjectPath,
+  validateSessionDir,
+  validateSubagentParent,
+  defaultIncludeContext,
+  hasContextBinding,
+  assertContextBinding,
+  resolveContextSessionScope,
+  validateSubagentLaunchProject,
+  isPathInside
+};

--- a/src/utils/sidecar-boundaries.js
+++ b/src/utils/sidecar-boundaries.js
@@ -84,6 +84,10 @@ function restrictedRootSet() {
   return roots;
 }
 
+function isRestrictedRoot(canonicalPath) {
+  return restrictedRootSet().has(canonicalPath);
+}
+
 function defaultIncludeContext() {
   return false;
 }
@@ -98,14 +102,16 @@ function validateProjectPath(project, options = {}) {
     return canonicalProject;
   }
 
-  if (restrictedRootSet().has(canonicalProject)) {
+  if (isRestrictedRoot(canonicalProject)) {
     throw new Error(`Project path is unsafe by default: ${canonicalProject}`);
   }
 
   const configuredRoots = options.allowedRoots !== undefined
     ? parseAllowedRoots(options.allowedRoots)
     : parseAllowedRoots(process.env.SIDECAR_ALLOWED_ROOTS);
-  const allowedRoots = [canonicalCwd, ...configuredRoots];
+  const allowedRoots = isRestrictedRoot(canonicalCwd)
+    ? configuredRoots
+    : [canonicalCwd, ...configuredRoots];
 
   if (!allowedRoots.some((root) => isPathInside(root, canonicalProject))) {
     throw new Error(`Project path is not allowed: ${canonicalProject}`);
@@ -154,11 +160,19 @@ function validateSubagentParent(metadata, projectRoot) {
   };
 }
 
+function isExactSessionBinding(value) {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const session = value.trim();
+  return session !== '' && session !== 'current';
+}
+
 function hasContextBinding(options = {}) {
   return Boolean(
-    options.parentSession ||
-    options.sessionId ||
-    options.session ||
+    isExactSessionBinding(options.parentSession) ||
+    isExactSessionBinding(options.sessionId) ||
+    isExactSessionBinding(options.session) ||
     options.sessionDir ||
     options.coworkProcess
   );
@@ -166,7 +180,7 @@ function hasContextBinding(options = {}) {
 
 function assertContextBinding(options = {}) {
   if (!hasContextBinding(options)) {
-    throw new Error('includeContext requires parentSession, session, sessionDir, or coworkProcess');
+    throw new Error('includeContext requires an exact parentSession/session, sessionDir, or coworkProcess');
   }
   if (options.client === 'cowork' && !options.sessionDir && !options.coworkProcess) {
     throw new Error('Cowork context requires coworkProcess for exact session matching');
@@ -193,14 +207,13 @@ function validateSubagentLaunchProject({ projectDir, parentTaskId, getSession, g
   if (!fs.existsSync(parentDir)) {
     throw new Error(`Parent session ${parentTaskId} not found`);
   }
-  const parentMetadata = getSession(validatedProjectDir, parentTaskId) || {
-    taskId: parentTaskId,
-    projectDir: validatedProjectDir
-  };
+  const parentMetadata = getSession(validatedProjectDir, parentTaskId);
+  if (!parentMetadata) {
+    throw new Error(`Parent session ${parentTaskId} metadata not found`);
+  }
   validateSubagentParent({
     ...parentMetadata,
-    taskId: parentMetadata.taskId || parentTaskId,
-    projectDir: parentMetadata.projectDir || parentMetadata.project || validatedProjectDir
+    taskId: parentMetadata.taskId || parentTaskId
   }, validatedProjectDir);
 
   return validatedProjectDir;

--- a/src/utils/sidecar-boundaries.js
+++ b/src/utils/sidecar-boundaries.js
@@ -168,19 +168,35 @@ function isExactSessionBinding(value) {
   return session !== '' && session !== 'current';
 }
 
+function resolveExactSessionFile(sessionDir, session) {
+  if (!isExactSessionBinding(session)) {
+    throw new Error('Exact session id is required for context inclusion');
+  }
+
+  const filename = session.endsWith('.jsonl') ? session : `${session}.jsonl`;
+  if (filename.includes('/') || filename.includes('\\') || filename.includes('\0')) {
+    throw new Error('Exact session id is invalid');
+  }
+
+  const sessionPath = path.join(sessionDir, filename);
+  if (!fs.existsSync(sessionPath)) {
+    throw new Error(`Exact session ${session} not found`);
+  }
+  return { path: sessionPath, method: 'explicit' };
+}
+
 function hasContextBinding(options = {}) {
   return Boolean(
     isExactSessionBinding(options.parentSession) ||
     isExactSessionBinding(options.sessionId) ||
     isExactSessionBinding(options.session) ||
-    options.sessionDir ||
     options.coworkProcess
   );
 }
 
 function assertContextBinding(options = {}) {
   if (!hasContextBinding(options)) {
-    throw new Error('includeContext requires an exact parentSession/session, sessionDir, or coworkProcess');
+    throw new Error('includeContext requires an exact parentSession/session or coworkProcess');
   }
   if (options.client === 'cowork' && !options.sessionDir && !options.coworkProcess) {
     throw new Error('Cowork context requires coworkProcess for exact session matching');
@@ -227,6 +243,8 @@ module.exports = {
   defaultIncludeContext,
   hasContextBinding,
   assertContextBinding,
+  isExactSessionBinding,
+  resolveExactSessionFile,
   resolveContextSessionScope,
   validateSubagentLaunchProject,
   isPathInside

--- a/src/utils/sidecar-env.js
+++ b/src/utils/sidecar-env.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const RUNTIME_ENV_KEYS = new Set([
+  'APPDATA',
+  'CI',
+  'COLORTERM',
+  'ComSpec',
+  'FORCE_COLOR',
+  'HOME',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'LOCALAPPDATA',
+  'LOG_LEVEL',
+  'LOGNAME',
+  'NODE_ENV',
+  'NO_COLOR',
+  'PATH',
+  'PATHEXT',
+  'PWD',
+  'SHELL',
+  'SystemRoot',
+  'TEMP',
+  'TERM',
+  'TMP',
+  'TMPDIR',
+  'USER',
+  'USERPROFILE',
+  'WINDIR',
+  'XDG_CACHE_HOME',
+  'XDG_CONFIG_HOME',
+  'XDG_DATA_HOME'
+]);
+
+function isSecretEnvKey(key) {
+  return /(?:SECRET|TOKEN|PASSWORD|CREDENTIAL|API_KEY|AUTH)/i.test(key);
+}
+
+function shouldCopyEnvKey(key) {
+  if (RUNTIME_ENV_KEYS.has(key)) {
+    return true;
+  }
+  if (key.startsWith('LC_')) {
+    return true;
+  }
+  if (key.startsWith('npm_') && !isSecretEnvKey(key)) {
+    return true;
+  }
+  if (key.startsWith('SIDECAR_') && !isSecretEnvKey(key)) {
+    return true;
+  }
+  return false;
+}
+
+function buildChildProcessEnv(extra = {}) {
+  const env = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && shouldCopyEnvKey(key)) {
+      env[key] = value;
+    }
+  }
+  for (const [key, value] of Object.entries(extra)) {
+    if (value !== undefined && value !== null) {
+      env[key] = String(value);
+    }
+  }
+  return env;
+}
+
+module.exports = { buildChildProcessEnv };

--- a/src/utils/sidecar-env.js
+++ b/src/utils/sidecar-env.js
@@ -67,4 +67,28 @@ function buildChildProcessEnv(extra = {}) {
   return env;
 }
 
-module.exports = { buildChildProcessEnv };
+function normalizeExtraEnv(extra) {
+  if (!extra || typeof extra !== 'object' || Array.isArray(extra)) {
+    return {};
+  }
+  return extra;
+}
+
+function buildMcpServerEnvironment(extra = {}) {
+  const explicit = normalizeExtraEnv(extra);
+  const env = buildChildProcessEnv(explicit);
+
+  for (const [key, value] of Object.entries(process.env)) {
+    if (
+      value !== undefined &&
+      isSecretEnvKey(key) &&
+      !Object.prototype.hasOwnProperty.call(explicit, key)
+    ) {
+      env[key] = '';
+    }
+  }
+
+  return env;
+}
+
+module.exports = { buildChildProcessEnv, buildMcpServerEnvironment };

--- a/src/utils/sidecar-session-boundaries.js
+++ b/src/utils/sidecar-session-boundaries.js
@@ -5,9 +5,7 @@ const path = require('path');
 const { validateTaskId } = require('./validators');
 
 function realpathSync(targetPath) {
-  return fs.realpathSync.native
-    ? fs.realpathSync.native(targetPath)
-    : fs.realpathSync(targetPath);
+  return fs.realpathSync.native ? fs.realpathSync.native(targetPath) : fs.realpathSync(targetPath);
 }
 
 function isPathInside(root, candidate) {
@@ -16,13 +14,55 @@ function isPathInside(root, candidate) {
 }
 
 function canonicalizeExistingDir(targetPath, label) {
-  if (!fs.existsSync(targetPath)) {
-    throw new Error(`${label} does not exist: ${targetPath}`);
-  }
+  if (!fs.existsSync(targetPath)) { throw new Error(`${label} does not exist: ${targetPath}`); }
   const canonical = realpathSync(targetPath);
   const stat = fs.statSync(canonical);
-  if (!stat.isDirectory()) {
-    throw new Error(`${label} is not a directory: ${targetPath}`);
+  if (!stat.isDirectory()) { throw new Error(`${label} is not a directory: ${targetPath}`); }
+  return canonical;
+}
+
+function rejectSymlink(targetPath, label) {
+  let stat;
+  try {
+    stat = fs.lstatSync(targetPath);
+  } catch (err) {
+    if (err && err.code === 'ENOENT') { return null; }
+    throw err;
+  }
+  if (stat.isSymbolicLink()) {
+    throw new Error(`${label} is a symbolic link and cannot be used safely inside the session directory: ${targetPath}`);
+  }
+  return stat;
+}
+
+function assertSafeSessionFilename(filename) {
+  if (!filename || typeof filename !== 'string') { throw new Error('Session filename is required'); }
+  if (filename.includes('\0') || filename.includes('/') || filename.includes('\\') || path.isAbsolute(filename)) {
+    throw new Error(`Invalid session filename: ${filename}`);
+  }
+}
+
+function assertTaskId(taskId) {
+  const taskCheck = validateTaskId(taskId);
+  if (!taskCheck.valid) { throw new Error(taskCheck.error); }
+}
+
+function ensureContainedDir(parentDir, dirname, label, options = {}) {
+  assertSafeSessionFilename(dirname);
+  const mode = options.mode === undefined ? 0o700 : options.mode;
+  const dirPath = path.join(parentDir, dirname);
+  if (!isPathInside(parentDir, path.resolve(dirPath))) {
+    throw new Error(`${label} is outside the expected parent directory: ${dirPath}`);
+  }
+
+  const existing = rejectSymlink(dirPath, label);
+  if (existing && !existing.isDirectory()) { throw new Error(`${label} is not a directory: ${dirPath}`); }
+  if (existing && options.allowExisting === false) { throw new Error(`${label} already exists: ${dirPath}`); }
+  if (!existing) { fs.mkdirSync(dirPath, { mode }); }
+
+  const canonical = canonicalizeExistingDir(dirPath, label);
+  if (!isPathInside(parentDir, canonical)) {
+    throw new Error(`${label} is outside the expected parent directory: ${canonical}`);
   }
   return canonical;
 }
@@ -30,56 +70,63 @@ function canonicalizeExistingDir(targetPath, label) {
 function validateSidecarSessionsRoot(projectRoot) {
   const canonicalProjectRoot = canonicalizeExistingDir(path.resolve(projectRoot), 'Project root');
   const sessionsRoot = path.join(canonicalProjectRoot, '.claude', 'sidecar_sessions');
+  if (!fs.existsSync(sessionsRoot)) { throw new Error(`Sidecar sessions root does not exist: ${sessionsRoot}`); }
 
-  if (!fs.existsSync(sessionsRoot)) {
-    throw new Error(`Sidecar sessions root does not exist: ${sessionsRoot}`);
-  }
-
+  rejectSymlink(sessionsRoot, 'Sidecar sessions root');
   const canonicalSessionsRoot = canonicalizeExistingDir(sessionsRoot, 'Sidecar sessions root');
   if (!isPathInside(canonicalProjectRoot, canonicalSessionsRoot)) {
     throw new Error(`Sidecar sessions root is outside the project root: ${canonicalSessionsRoot}`);
   }
-
   return canonicalSessionsRoot;
 }
 
-function validateSidecarSessionDir(projectRoot, taskId) {
-  const taskCheck = validateTaskId(taskId);
-  if (!taskCheck.valid) {
-    throw new Error(taskCheck.error);
-  }
-
+function ensureSidecarSessionsRoot(projectRoot) {
   const canonicalProjectRoot = canonicalizeExistingDir(path.resolve(projectRoot), 'Project root');
-  const requestedSessionsRoot = path.join(canonicalProjectRoot, '.claude', 'sidecar_sessions');
-  if (!fs.existsSync(requestedSessionsRoot)) {
-    throw new Error(`Session ${taskId} not found`);
+  const claudeDir = ensureContainedDir(canonicalProjectRoot, '.claude', 'Claude metadata directory');
+  const sessionsRoot = ensureContainedDir(claudeDir, 'sidecar_sessions', 'Sidecar sessions root');
+  if (!isPathInside(canonicalProjectRoot, sessionsRoot)) {
+    throw new Error(`Sidecar sessions root is outside the project root: ${sessionsRoot}`);
   }
+  return sessionsRoot;
+}
 
-  const canonicalSessionsRoot = validateSidecarSessionsRoot(projectRoot);
+function ensureSidecarSessionDir(projectRoot, taskId, options = {}) {
+  assertTaskId(taskId);
+  const canonicalSessionsRoot = ensureSidecarSessionsRoot(projectRoot);
   const sessionDir = path.join(canonicalSessionsRoot, taskId);
+  const existing = rejectSymlink(sessionDir, 'Session directory');
+  if (existing && !existing.isDirectory()) { throw new Error(`Session path is not a directory: ${sessionDir}`); }
+  if (existing && options.allowExisting === false) { throw new Error(`Session ${taskId} already exists`); }
+  if (!existing) { fs.mkdirSync(sessionDir, { mode: options.mode === undefined ? 0o700 : options.mode }); }
 
-  if (!fs.existsSync(sessionDir)) {
-    throw new Error(`Session ${taskId} not found`);
-  }
-
-  const canonicalSessionDir = realpathSync(sessionDir);
-  const stat = fs.statSync(canonicalSessionDir);
-  if (!stat.isDirectory()) {
-    throw new Error(`Session path is not a directory: ${sessionDir}`);
-  }
+  const canonicalSessionDir = canonicalizeExistingDir(sessionDir, 'Session directory');
   if (!isPathInside(canonicalSessionsRoot, canonicalSessionDir)) {
     throw new Error(`Session directory is outside the project session root: ${canonicalSessionDir}`);
   }
+  return canonicalSessionDir;
+}
 
+function validateSidecarSessionDir(projectRoot, taskId) {
+  assertTaskId(taskId);
+  const canonicalProjectRoot = canonicalizeExistingDir(path.resolve(projectRoot), 'Project root');
+  const requestedSessionsRoot = path.join(canonicalProjectRoot, '.claude', 'sidecar_sessions');
+  if (!fs.existsSync(requestedSessionsRoot)) { throw new Error(`Session ${taskId} not found`); }
+
+  const canonicalSessionsRoot = validateSidecarSessionsRoot(projectRoot);
+  const sessionDir = path.join(canonicalSessionsRoot, taskId);
+  if (!fs.existsSync(sessionDir)) { throw new Error(`Session ${taskId} not found`); }
+
+  const canonicalSessionDir = realpathSync(sessionDir);
+  const stat = fs.statSync(canonicalSessionDir);
+  if (!stat.isDirectory()) { throw new Error(`Session path is not a directory: ${sessionDir}`); }
+  if (!isPathInside(canonicalSessionsRoot, canonicalSessionDir)) {
+    throw new Error(`Session directory is outside the project session root: ${canonicalSessionDir}`);
+  }
   return canonicalSessionDir;
 }
 
 function validateSidecarSubagentSessionDir(projectRoot, parentTaskId, subagentId) {
-  const subagentCheck = validateTaskId(subagentId);
-  if (!subagentCheck.valid) {
-    throw new Error(subagentCheck.error);
-  }
-
+  assertTaskId(subagentId);
   const canonicalParentSessionDir = validateSidecarSessionDir(projectRoot, parentTaskId);
   const subagentsRoot = path.join(canonicalParentSessionDir, 'subagents');
   if (!fs.existsSync(subagentsRoot)) {
@@ -98,46 +145,24 @@ function validateSidecarSubagentSessionDir(projectRoot, parentTaskId, subagentId
 
   const canonicalSubagentDir = realpathSync(subagentDir);
   const stat = fs.statSync(canonicalSubagentDir);
-  if (!stat.isDirectory()) {
-    throw new Error(`Sub-agent path is not a directory: ${subagentDir}`);
-  }
+  if (!stat.isDirectory()) { throw new Error(`Sub-agent path is not a directory: ${subagentDir}`); }
   if (!isPathInside(canonicalSubagentsRoot, canonicalSubagentDir)) {
     throw new Error(`Sub-agent session directory is outside the parent session tree: ${canonicalSubagentDir}`);
   }
-
   return canonicalSubagentDir;
 }
 
 function validateSidecarSessionMetadata(metadata, projectRoot) {
-  if (!metadata || typeof metadata !== 'object') {
-    throw new Error('Session metadata is required');
-  }
-
+  if (!metadata || typeof metadata !== 'object') { throw new Error('Session metadata is required'); }
   const metadataProject = metadata.projectDir || metadata.project || metadata.cwd;
-  if (!metadataProject) {
-    throw new Error('Session metadata is missing project binding');
-  }
+  if (!metadataProject) { throw new Error('Session metadata is missing project binding'); }
 
   const canonicalProjectRoot = canonicalizeExistingDir(path.resolve(projectRoot), 'Project root');
   const canonicalMetadataProject = canonicalizeExistingDir(path.resolve(metadataProject), 'Session metadata project');
   if (canonicalMetadataProject !== canonicalProjectRoot) {
     throw new Error(`Session metadata project does not match project root: ${canonicalMetadataProject}`);
   }
-
-  return {
-    ...metadata,
-    project: canonicalProjectRoot,
-    projectDir: canonicalProjectRoot
-  };
-}
-
-function assertSafeSessionFilename(filename) {
-  if (!filename || typeof filename !== 'string') {
-    throw new Error('Session filename is required');
-  }
-  if (filename.includes('\0') || filename.includes('/') || filename.includes('\\') || path.isAbsolute(filename)) {
-    throw new Error(`Invalid session filename: ${filename}`);
-  }
+  return { ...metadata, project: canonicalProjectRoot, projectDir: canonicalProjectRoot };
 }
 
 function resolveContainedSessionFile(sessionDir, filename, options = {}) {
@@ -146,9 +171,7 @@ function resolveContainedSessionFile(sessionDir, filename, options = {}) {
   const filePath = path.join(canonicalSessionDir, filename);
 
   if (!fs.existsSync(filePath)) {
-    if (options.optional) {
-      return null;
-    }
+    if (options.optional) { return null; }
     throw new Error(`Session file not found: ${filename}`);
   }
 
@@ -158,50 +181,60 @@ function resolveContainedSessionFile(sessionDir, filename, options = {}) {
   }
 
   const stat = fs.statSync(canonicalFilePath);
-  if (!stat.isFile()) {
-    throw new Error(`Session file is not a regular file: ${filename}`);
-  }
-
+  if (!stat.isFile()) { throw new Error(`Session file is not a regular file: ${filename}`); }
   return { path: canonicalFilePath, stat };
 }
 
 function readContainedSessionFile(sessionDir, filename, options = {}) {
   const resolved = resolveContainedSessionFile(sessionDir, filename, options);
-  if (resolved === null) {
-    return null;
-  }
-
-  return fs.readFileSync(resolved.path, 'utf-8');
+  return resolved === null ? null : fs.readFileSync(resolved.path, 'utf-8');
 }
 
-function openContainedSessionFileForWrite(sessionDir, filename, options = {}) {
+function prepareContainedSessionFile(sessionDir, filename) {
   assertSafeSessionFilename(filename);
   const canonicalSessionDir = canonicalizeExistingDir(path.resolve(sessionDir), 'Session directory');
   const filePath = path.join(canonicalSessionDir, filename);
-  const mode = options.mode === undefined ? 0o600 : options.mode;
-  const flags = fs.constants.O_WRONLY |
-    fs.constants.O_CREAT |
-    fs.constants.O_TRUNC |
-    (fs.constants.O_NOFOLLOW || 0);
+  if (!isPathInside(canonicalSessionDir, path.resolve(filePath))) {
+    throw new Error(`Session file is outside the session directory: ${filename}`);
+  }
 
+  const existing = rejectSymlink(filePath, 'Session file');
+  if (existing && !existing.isFile()) { throw new Error(`Session file is not a regular file: ${filename}`); }
+  if (existing && !isPathInside(canonicalSessionDir, realpathSync(filePath))) {
+    throw new Error(`Session file is outside the session directory: ${filename}`);
+  }
+  return filePath;
+}
+
+function openPreparedSessionFile(filePath, filename, flags, mode, action) {
   try {
-    return fs.openSync(filePath, flags, mode);
+    const fd = fs.openSync(filePath, flags, mode);
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile()) {
+      fs.closeSync(fd);
+      throw new Error(`Session file is not a regular file: ${filename}`);
+    }
+    return fd;
   } catch (err) {
     if (err && err.code === 'ELOOP') {
-      throw new Error(`Session file is a symbolic link and cannot be written safely inside the session directory: ${filename}`);
+      throw new Error(`Session file is a symbolic link and cannot be ${action} safely inside the session directory: ${filename}`);
     }
     throw err;
   }
 }
 
 function normalizeWriteOptions(options) {
-  if (typeof options === 'string') {
-    return { encoding: options };
-  }
+  if (typeof options === 'string') { return { encoding: options }; }
   const normalized = { ...options };
   delete normalized.flag;
   delete normalized.mode;
   return normalized;
+}
+
+function openContainedSessionFileForWrite(sessionDir, filename, options = {}) {
+  const mode = options.mode === undefined ? 0o600 : options.mode;
+  const flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC | (fs.constants.O_NOFOLLOW || 0);
+  return openPreparedSessionFile(prepareContainedSessionFile(sessionDir, filename), filename, flags, mode, 'written');
 }
 
 function writeContainedSessionFile(sessionDir, filename, data, options = {}) {
@@ -213,13 +246,26 @@ function writeContainedSessionFile(sessionDir, filename, data, options = {}) {
   }
 }
 
+function appendContainedSessionFile(sessionDir, filename, data, options = {}) {
+  const mode = options.mode === undefined ? 0o600 : options.mode;
+  const flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_APPEND | (fs.constants.O_NOFOLLOW || 0);
+  const fd = openPreparedSessionFile(prepareContainedSessionFile(sessionDir, filename), filename, flags, mode, 'appended');
+  try {
+    fs.writeFileSync(fd, data, normalizeWriteOptions(options));
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
 module.exports = {
   validateSidecarSessionsRoot,
+  ensureSidecarSessionDir,
   validateSidecarSessionDir,
   validateSidecarSubagentSessionDir,
   validateSidecarSessionMetadata,
   resolveContainedSessionFile,
   readContainedSessionFile,
   openContainedSessionFileForWrite,
-  writeContainedSessionFile
+  writeContainedSessionFile,
+  appendContainedSessionFile
 };

--- a/src/utils/sidecar-session-boundaries.js
+++ b/src/utils/sidecar-session-boundaries.js
@@ -143,20 +143,25 @@ function ensureSidecarSubagentSessionDir(projectRoot, parentTaskId, subagentId, 
   );
 }
 
-function validateSidecarSubagentSessionDir(projectRoot, parentTaskId, subagentId) {
-  assertTaskId(subagentId);
+function validateSidecarSubagentsRoot(projectRoot, parentTaskId, options = {}) {
   const canonicalParentSessionDir = validateSidecarSessionDir(projectRoot, parentTaskId);
   const subagentsRoot = path.join(canonicalParentSessionDir, 'subagents');
   rejectSymlink(subagentsRoot, 'Sub-agent sessions root');
   if (!fs.existsSync(subagentsRoot)) {
-    throw new Error(`Sub-agent ${subagentId} not found under parent ${parentTaskId}`);
+    if (options.optional) { return null; }
+    throw new Error(`Sub-agent sessions root not found under parent ${parentTaskId}`);
   }
-
   const canonicalSubagentsRoot = canonicalizeExistingDir(subagentsRoot, 'Sub-agent sessions root');
   if (!isPathInside(canonicalParentSessionDir, canonicalSubagentsRoot)) {
     throw new Error(`Sub-agent sessions root is outside the parent session directory: ${canonicalSubagentsRoot}`);
   }
+  return canonicalSubagentsRoot;
+}
 
+function validateSidecarSubagentSessionDir(projectRoot, parentTaskId, subagentId) {
+  assertTaskId(subagentId);
+  const canonicalSubagentsRoot = validateSidecarSubagentsRoot(projectRoot, parentTaskId, { optional: true });
+  if (!canonicalSubagentsRoot) { throw new Error(`Sub-agent ${subagentId} not found under parent ${parentTaskId}`); }
   const subagentDir = path.join(canonicalSubagentsRoot, subagentId);
   rejectSymlink(subagentDir, 'Sub-agent session directory');
   if (!fs.existsSync(subagentDir)) {
@@ -283,6 +288,7 @@ module.exports = {
   ensureSidecarSessionDir,
   validateSidecarSessionDir,
   ensureSidecarSubagentSessionDir,
+  validateSidecarSubagentsRoot,
   validateSidecarSubagentSessionDir,
   validateSidecarSessionMetadata,
   resolveContainedSessionFile,

--- a/src/utils/sidecar-session-boundaries.js
+++ b/src/utils/sidecar-session-boundaries.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { validateTaskId } = require('./validators');
+
+function realpathSync(targetPath) {
+  return fs.realpathSync.native
+    ? fs.realpathSync.native(targetPath)
+    : fs.realpathSync(targetPath);
+}
+
+function isPathInside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function canonicalizeExistingDir(targetPath, label) {
+  if (!fs.existsSync(targetPath)) {
+    throw new Error(`${label} does not exist: ${targetPath}`);
+  }
+  const canonical = realpathSync(targetPath);
+  const stat = fs.statSync(canonical);
+  if (!stat.isDirectory()) {
+    throw new Error(`${label} is not a directory: ${targetPath}`);
+  }
+  return canonical;
+}
+
+function validateSidecarSessionDir(projectRoot, taskId) {
+  const taskCheck = validateTaskId(taskId);
+  if (!taskCheck.valid) {
+    throw new Error(taskCheck.error);
+  }
+
+  const canonicalProjectRoot = canonicalizeExistingDir(path.resolve(projectRoot), 'Project root');
+  const sessionsRoot = path.join(canonicalProjectRoot, '.claude', 'sidecar_sessions');
+  const sessionDir = path.join(sessionsRoot, taskId);
+
+  if (!fs.existsSync(sessionDir)) {
+    throw new Error(`Session ${taskId} not found`);
+  }
+
+  const canonicalSessionsRoot = canonicalizeExistingDir(sessionsRoot, 'Sidecar sessions root');
+  if (!isPathInside(canonicalProjectRoot, canonicalSessionsRoot)) {
+    throw new Error(`Sidecar sessions root is outside the project root: ${canonicalSessionsRoot}`);
+  }
+
+  const canonicalSessionDir = realpathSync(sessionDir);
+  const stat = fs.statSync(canonicalSessionDir);
+  if (!stat.isDirectory()) {
+    throw new Error(`Session path is not a directory: ${sessionDir}`);
+  }
+  if (!isPathInside(canonicalSessionsRoot, canonicalSessionDir)) {
+    throw new Error(`Session directory is outside the project session root: ${canonicalSessionDir}`);
+  }
+
+  return canonicalSessionDir;
+}
+
+function validateSidecarSessionMetadata(metadata, projectRoot) {
+  if (!metadata || typeof metadata !== 'object') {
+    throw new Error('Session metadata is required');
+  }
+
+  const metadataProject = metadata.projectDir || metadata.project || metadata.cwd;
+  if (!metadataProject) {
+    throw new Error('Session metadata is missing project binding');
+  }
+
+  const canonicalProjectRoot = canonicalizeExistingDir(path.resolve(projectRoot), 'Project root');
+  const canonicalMetadataProject = canonicalizeExistingDir(path.resolve(metadataProject), 'Session metadata project');
+  if (canonicalMetadataProject !== canonicalProjectRoot) {
+    throw new Error(`Session metadata project does not match project root: ${canonicalMetadataProject}`);
+  }
+
+  return {
+    ...metadata,
+    project: canonicalProjectRoot,
+    projectDir: canonicalProjectRoot
+  };
+}
+
+module.exports = {
+  validateSidecarSessionDir,
+  validateSidecarSessionMetadata
+};

--- a/src/utils/sidecar-session-boundaries.js
+++ b/src/utils/sidecar-session-boundaries.js
@@ -81,7 +81,42 @@ function validateSidecarSessionMetadata(metadata, projectRoot) {
   };
 }
 
+function assertSafeSessionFilename(filename) {
+  if (!filename || typeof filename !== 'string') {
+    throw new Error('Session filename is required');
+  }
+  if (filename.includes('\0') || filename.includes('/') || filename.includes('\\') || path.isAbsolute(filename)) {
+    throw new Error(`Invalid session filename: ${filename}`);
+  }
+}
+
+function readContainedSessionFile(sessionDir, filename, options = {}) {
+  assertSafeSessionFilename(filename);
+  const canonicalSessionDir = canonicalizeExistingDir(path.resolve(sessionDir), 'Session directory');
+  const filePath = path.join(canonicalSessionDir, filename);
+
+  if (!fs.existsSync(filePath)) {
+    if (options.optional) {
+      return null;
+    }
+    throw new Error(`Session file not found: ${filename}`);
+  }
+
+  const canonicalFilePath = realpathSync(filePath);
+  if (!isPathInside(canonicalSessionDir, canonicalFilePath)) {
+    throw new Error(`Session file is outside the session directory: ${filename}`);
+  }
+
+  const stat = fs.statSync(canonicalFilePath);
+  if (!stat.isFile()) {
+    throw new Error(`Session file is not a regular file: ${filename}`);
+  }
+
+  return fs.readFileSync(canonicalFilePath, 'utf-8');
+}
+
 module.exports = {
   validateSidecarSessionDir,
-  validateSidecarSessionMetadata
+  validateSidecarSessionMetadata,
+  readContainedSessionFile
 };

--- a/src/utils/sidecar-session-boundaries.js
+++ b/src/utils/sidecar-session-boundaries.js
@@ -70,9 +70,9 @@ function ensureContainedDir(parentDir, dirname, label, options = {}) {
 function validateSidecarSessionsRoot(projectRoot) {
   const canonicalProjectRoot = canonicalizeExistingDir(path.resolve(projectRoot), 'Project root');
   const sessionsRoot = path.join(canonicalProjectRoot, '.claude', 'sidecar_sessions');
+  rejectSymlink(sessionsRoot, 'Sidecar sessions root');
   if (!fs.existsSync(sessionsRoot)) { throw new Error(`Sidecar sessions root does not exist: ${sessionsRoot}`); }
 
-  rejectSymlink(sessionsRoot, 'Sidecar sessions root');
   const canonicalSessionsRoot = canonicalizeExistingDir(sessionsRoot, 'Sidecar sessions root');
   if (!isPathInside(canonicalProjectRoot, canonicalSessionsRoot)) {
     throw new Error(`Sidecar sessions root is outside the project root: ${canonicalSessionsRoot}`);
@@ -110,10 +110,12 @@ function validateSidecarSessionDir(projectRoot, taskId) {
   assertTaskId(taskId);
   const canonicalProjectRoot = canonicalizeExistingDir(path.resolve(projectRoot), 'Project root');
   const requestedSessionsRoot = path.join(canonicalProjectRoot, '.claude', 'sidecar_sessions');
+  rejectSymlink(requestedSessionsRoot, 'Sidecar sessions root');
   if (!fs.existsSync(requestedSessionsRoot)) { throw new Error(`Session ${taskId} not found`); }
 
   const canonicalSessionsRoot = validateSidecarSessionsRoot(projectRoot);
   const sessionDir = path.join(canonicalSessionsRoot, taskId);
+  rejectSymlink(sessionDir, 'Session directory inside project session root');
   if (!fs.existsSync(sessionDir)) { throw new Error(`Session ${taskId} not found`); }
 
   const canonicalSessionDir = realpathSync(sessionDir);
@@ -125,10 +127,27 @@ function validateSidecarSessionDir(projectRoot, taskId) {
   return canonicalSessionDir;
 }
 
+function ensureSidecarSubagentSessionDir(projectRoot, parentTaskId, subagentId, options = {}) {
+  assertTaskId(subagentId);
+  const canonicalParentSessionDir = validateSidecarSessionDir(projectRoot, parentTaskId);
+  const subagentsRoot = ensureContainedDir(
+    canonicalParentSessionDir,
+    'subagents',
+    'Sub-agent sessions root'
+  );
+  return ensureContainedDir(
+    subagentsRoot,
+    subagentId,
+    'Sub-agent session directory',
+    { allowExisting: options.allowExisting, mode: options.mode === undefined ? 0o700 : options.mode }
+  );
+}
+
 function validateSidecarSubagentSessionDir(projectRoot, parentTaskId, subagentId) {
   assertTaskId(subagentId);
   const canonicalParentSessionDir = validateSidecarSessionDir(projectRoot, parentTaskId);
   const subagentsRoot = path.join(canonicalParentSessionDir, 'subagents');
+  rejectSymlink(subagentsRoot, 'Sub-agent sessions root');
   if (!fs.existsSync(subagentsRoot)) {
     throw new Error(`Sub-agent ${subagentId} not found under parent ${parentTaskId}`);
   }
@@ -139,6 +158,7 @@ function validateSidecarSubagentSessionDir(projectRoot, parentTaskId, subagentId
   }
 
   const subagentDir = path.join(canonicalSubagentsRoot, subagentId);
+  rejectSymlink(subagentDir, 'Sub-agent session directory');
   if (!fs.existsSync(subagentDir)) {
     throw new Error(`Sub-agent ${subagentId} not found under parent ${parentTaskId}`);
   }
@@ -169,6 +189,7 @@ function resolveContainedSessionFile(sessionDir, filename, options = {}) {
   assertSafeSessionFilename(filename);
   const canonicalSessionDir = canonicalizeExistingDir(path.resolve(sessionDir), 'Session directory');
   const filePath = path.join(canonicalSessionDir, filename);
+  rejectSymlink(filePath, 'Session file');
 
   if (!fs.existsSync(filePath)) {
     if (options.optional) { return null; }
@@ -261,6 +282,7 @@ module.exports = {
   validateSidecarSessionsRoot,
   ensureSidecarSessionDir,
   validateSidecarSessionDir,
+  ensureSidecarSubagentSessionDir,
   validateSidecarSubagentSessionDir,
   validateSidecarSessionMetadata,
   resolveContainedSessionFile,

--- a/src/utils/sidecar-session-boundaries.js
+++ b/src/utils/sidecar-session-boundaries.js
@@ -174,18 +174,43 @@ function readContainedSessionFile(sessionDir, filename, options = {}) {
   return fs.readFileSync(resolved.path, 'utf-8');
 }
 
-function writeContainedSessionFile(sessionDir, filename, data, options = {}) {
+function openContainedSessionFileForWrite(sessionDir, filename, options = {}) {
   assertSafeSessionFilename(filename);
   const canonicalSessionDir = canonicalizeExistingDir(path.resolve(sessionDir), 'Session directory');
   const filePath = path.join(canonicalSessionDir, filename);
+  const mode = options.mode === undefined ? 0o600 : options.mode;
+  const flags = fs.constants.O_WRONLY |
+    fs.constants.O_CREAT |
+    fs.constants.O_TRUNC |
+    (fs.constants.O_NOFOLLOW || 0);
 
-  let targetPath = filePath;
-  if (fs.existsSync(filePath)) {
-    const resolved = resolveContainedSessionFile(canonicalSessionDir, filename);
-    targetPath = resolved.path;
+  try {
+    return fs.openSync(filePath, flags, mode);
+  } catch (err) {
+    if (err && err.code === 'ELOOP') {
+      throw new Error(`Session file is a symbolic link and cannot be written safely inside the session directory: ${filename}`);
+    }
+    throw err;
   }
+}
 
-  fs.writeFileSync(targetPath, data, options);
+function normalizeWriteOptions(options) {
+  if (typeof options === 'string') {
+    return { encoding: options };
+  }
+  const normalized = { ...options };
+  delete normalized.flag;
+  delete normalized.mode;
+  return normalized;
+}
+
+function writeContainedSessionFile(sessionDir, filename, data, options = {}) {
+  const fd = openContainedSessionFileForWrite(sessionDir, filename, options);
+  try {
+    fs.writeFileSync(fd, data, normalizeWriteOptions(options));
+  } finally {
+    fs.closeSync(fd);
+  }
 }
 
 module.exports = {
@@ -195,5 +220,6 @@ module.exports = {
   validateSidecarSessionMetadata,
   resolveContainedSessionFile,
   readContainedSessionFile,
+  openContainedSessionFileForWrite,
   writeContainedSessionFile
 };

--- a/src/utils/sidecar-session-boundaries.js
+++ b/src/utils/sidecar-session-boundaries.js
@@ -27,6 +27,22 @@ function canonicalizeExistingDir(targetPath, label) {
   return canonical;
 }
 
+function validateSidecarSessionsRoot(projectRoot) {
+  const canonicalProjectRoot = canonicalizeExistingDir(path.resolve(projectRoot), 'Project root');
+  const sessionsRoot = path.join(canonicalProjectRoot, '.claude', 'sidecar_sessions');
+
+  if (!fs.existsSync(sessionsRoot)) {
+    throw new Error(`Sidecar sessions root does not exist: ${sessionsRoot}`);
+  }
+
+  const canonicalSessionsRoot = canonicalizeExistingDir(sessionsRoot, 'Sidecar sessions root');
+  if (!isPathInside(canonicalProjectRoot, canonicalSessionsRoot)) {
+    throw new Error(`Sidecar sessions root is outside the project root: ${canonicalSessionsRoot}`);
+  }
+
+  return canonicalSessionsRoot;
+}
+
 function validateSidecarSessionDir(projectRoot, taskId) {
   const taskCheck = validateTaskId(taskId);
   if (!taskCheck.valid) {
@@ -34,16 +50,16 @@ function validateSidecarSessionDir(projectRoot, taskId) {
   }
 
   const canonicalProjectRoot = canonicalizeExistingDir(path.resolve(projectRoot), 'Project root');
-  const sessionsRoot = path.join(canonicalProjectRoot, '.claude', 'sidecar_sessions');
-  const sessionDir = path.join(sessionsRoot, taskId);
-
-  if (!fs.existsSync(sessionDir)) {
+  const requestedSessionsRoot = path.join(canonicalProjectRoot, '.claude', 'sidecar_sessions');
+  if (!fs.existsSync(requestedSessionsRoot)) {
     throw new Error(`Session ${taskId} not found`);
   }
 
-  const canonicalSessionsRoot = canonicalizeExistingDir(sessionsRoot, 'Sidecar sessions root');
-  if (!isPathInside(canonicalProjectRoot, canonicalSessionsRoot)) {
-    throw new Error(`Sidecar sessions root is outside the project root: ${canonicalSessionsRoot}`);
+  const canonicalSessionsRoot = validateSidecarSessionsRoot(projectRoot);
+  const sessionDir = path.join(canonicalSessionsRoot, taskId);
+
+  if (!fs.existsSync(sessionDir)) {
+    throw new Error(`Session ${taskId} not found`);
   }
 
   const canonicalSessionDir = realpathSync(sessionDir);
@@ -56,6 +72,40 @@ function validateSidecarSessionDir(projectRoot, taskId) {
   }
 
   return canonicalSessionDir;
+}
+
+function validateSidecarSubagentSessionDir(projectRoot, parentTaskId, subagentId) {
+  const subagentCheck = validateTaskId(subagentId);
+  if (!subagentCheck.valid) {
+    throw new Error(subagentCheck.error);
+  }
+
+  const canonicalParentSessionDir = validateSidecarSessionDir(projectRoot, parentTaskId);
+  const subagentsRoot = path.join(canonicalParentSessionDir, 'subagents');
+  if (!fs.existsSync(subagentsRoot)) {
+    throw new Error(`Sub-agent ${subagentId} not found under parent ${parentTaskId}`);
+  }
+
+  const canonicalSubagentsRoot = canonicalizeExistingDir(subagentsRoot, 'Sub-agent sessions root');
+  if (!isPathInside(canonicalParentSessionDir, canonicalSubagentsRoot)) {
+    throw new Error(`Sub-agent sessions root is outside the parent session directory: ${canonicalSubagentsRoot}`);
+  }
+
+  const subagentDir = path.join(canonicalSubagentsRoot, subagentId);
+  if (!fs.existsSync(subagentDir)) {
+    throw new Error(`Sub-agent ${subagentId} not found under parent ${parentTaskId}`);
+  }
+
+  const canonicalSubagentDir = realpathSync(subagentDir);
+  const stat = fs.statSync(canonicalSubagentDir);
+  if (!stat.isDirectory()) {
+    throw new Error(`Sub-agent path is not a directory: ${subagentDir}`);
+  }
+  if (!isPathInside(canonicalSubagentsRoot, canonicalSubagentDir)) {
+    throw new Error(`Sub-agent session directory is outside the parent session tree: ${canonicalSubagentDir}`);
+  }
+
+  return canonicalSubagentDir;
 }
 
 function validateSidecarSessionMetadata(metadata, projectRoot) {
@@ -90,7 +140,7 @@ function assertSafeSessionFilename(filename) {
   }
 }
 
-function readContainedSessionFile(sessionDir, filename, options = {}) {
+function resolveContainedSessionFile(sessionDir, filename, options = {}) {
   assertSafeSessionFilename(filename);
   const canonicalSessionDir = canonicalizeExistingDir(path.resolve(sessionDir), 'Session directory');
   const filePath = path.join(canonicalSessionDir, filename);
@@ -112,11 +162,38 @@ function readContainedSessionFile(sessionDir, filename, options = {}) {
     throw new Error(`Session file is not a regular file: ${filename}`);
   }
 
-  return fs.readFileSync(canonicalFilePath, 'utf-8');
+  return { path: canonicalFilePath, stat };
+}
+
+function readContainedSessionFile(sessionDir, filename, options = {}) {
+  const resolved = resolveContainedSessionFile(sessionDir, filename, options);
+  if (resolved === null) {
+    return null;
+  }
+
+  return fs.readFileSync(resolved.path, 'utf-8');
+}
+
+function writeContainedSessionFile(sessionDir, filename, data, options = {}) {
+  assertSafeSessionFilename(filename);
+  const canonicalSessionDir = canonicalizeExistingDir(path.resolve(sessionDir), 'Session directory');
+  const filePath = path.join(canonicalSessionDir, filename);
+
+  let targetPath = filePath;
+  if (fs.existsSync(filePath)) {
+    const resolved = resolveContainedSessionFile(canonicalSessionDir, filename);
+    targetPath = resolved.path;
+  }
+
+  fs.writeFileSync(targetPath, data, options);
 }
 
 module.exports = {
+  validateSidecarSessionsRoot,
   validateSidecarSessionDir,
+  validateSidecarSubagentSessionDir,
   validateSidecarSessionMetadata,
-  readContainedSessionFile
+  resolveContainedSessionFile,
+  readContainedSessionFile,
+  writeContainedSessionFile
 };

--- a/src/utils/start-helpers.js
+++ b/src/utils/start-helpers.js
@@ -18,7 +18,7 @@ function resolveModelFromArgs(args) {
   try {
     model = resolveModel(args.model);
   } catch (err) {
-    console.error(err.message);
+    process.stderr.write(`${err.message}\n`);
     process.exit(1);
   }
 
@@ -51,7 +51,7 @@ async function validateFallbackModel(args, alias) {
       headless: args['no-ui'] || !process.stdin.isTTY
     });
   } catch (err) {
-    console.error(err.message);
+    process.stderr.write(`${err.message}\n`);
     process.exit(1);
   }
 }

--- a/tests/cli-handler.integration.test.js
+++ b/tests/cli-handler.integration.test.js
@@ -187,6 +187,35 @@ describe('CLI Handler Integration: path traversal safety', () => {
     }
   });
 
+  it('abort rejects a symlinked metadata file without modifying the outside target', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-abort-meta-'));
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-abort-outside-'));
+    try {
+      const sessDir = path.join(tmpDir, '.claude', 'sidecar_sessions', 'abort-meta');
+      fs.mkdirSync(sessDir, { recursive: true });
+      const outsideMetadata = path.join(outsideDir, 'metadata.json');
+      fs.writeFileSync(outsideMetadata, JSON.stringify({
+        taskId: 'abort-meta',
+        model: 'gemini',
+        status: 'running',
+        briefing: 'outside metadata',
+        createdAt: '2026-03-04T00:00:00Z'
+      }));
+      fs.symlinkSync(outsideMetadata, path.join(sessDir, 'metadata.json'));
+
+      const { stderr, code } = await runCli(['abort', 'abort-meta', '--cwd', tmpDir]);
+
+      expect(code).toBe(1);
+      expect(stderr.toLowerCase()).toMatch(/outside|session directory/);
+      const parsed = JSON.parse(fs.readFileSync(outsideMetadata, 'utf-8'));
+      expect(parsed.status).toBe('running');
+      expect(parsed.abortedAt).toBeUndefined();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
   it('rejects path traversal in task ID for read', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-safety-'));
     try {

--- a/tests/cli-handler.integration.test.js
+++ b/tests/cli-handler.integration.test.js
@@ -197,4 +197,96 @@ describe('CLI Handler Integration: path traversal safety', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it('read rejects a symlinked task directory before printing outside summary', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-read-symlink-'));
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-read-outside-'));
+    try {
+      const sessionsDir = path.join(tmpDir, '.claude', 'sidecar_sessions');
+      fs.mkdirSync(sessionsDir, { recursive: true });
+      fs.writeFileSync(path.join(outsideDir, 'metadata.json'), JSON.stringify({
+        taskId: 'leak',
+        status: 'complete',
+        createdAt: '2026-03-04T00:00:00Z'
+      }));
+      fs.writeFileSync(path.join(outsideDir, 'summary.md'), 'outside secret summary');
+      fs.symlinkSync(outsideDir, path.join(sessionsDir, 'leak'), 'dir');
+
+      const { stdout, stderr, code } = await runCli(['read', 'leak', '--cwd', tmpDir]);
+
+      expect(code).toBe(1);
+      expect(stdout).not.toContain('outside secret summary');
+      expect(stderr.toLowerCase()).toMatch(/outside|session root|session directory/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('read --conversation rejects a symlinked conversation file before printing outside content', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-conv-symlink-'));
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-conv-outside-'));
+    try {
+      const sessDir = path.join(tmpDir, '.claude', 'sidecar_sessions', 'convleak');
+      fs.mkdirSync(sessDir, { recursive: true });
+      fs.writeFileSync(path.join(sessDir, 'metadata.json'), JSON.stringify({
+        taskId: 'convleak',
+        status: 'complete',
+        createdAt: '2026-03-04T00:00:00Z'
+      }));
+      const outsideConversation = path.join(outsideDir, 'conversation.jsonl');
+      fs.writeFileSync(
+        outsideConversation,
+        JSON.stringify({ role: 'assistant', content: 'outside secret conversation' }) + '\n'
+      );
+      fs.symlinkSync(outsideConversation, path.join(sessDir, 'conversation.jsonl'));
+
+      const { stdout, stderr, code } = await runCli([
+        'read', 'convleak', '--cwd', tmpDir, '--conversation'
+      ]);
+
+      expect(code).toBe(1);
+      expect(stdout).not.toContain('outside secret conversation');
+      expect(stderr.toLowerCase()).toMatch(/outside|session directory/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('list skips symlinked task directories instead of printing outside metadata', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-list-symlink-'));
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-list-outside-'));
+    try {
+      const sessionsDir = path.join(tmpDir, '.claude', 'sidecar_sessions');
+      const validDir = path.join(sessionsDir, 'valid-task');
+      fs.mkdirSync(validDir, { recursive: true });
+      fs.writeFileSync(path.join(validDir, 'metadata.json'), JSON.stringify({
+        taskId: 'valid-task',
+        model: 'gemini',
+        status: 'complete',
+        briefing: 'inside session',
+        createdAt: '2026-03-04T00:00:00Z'
+      }));
+      fs.writeFileSync(path.join(outsideDir, 'metadata.json'), JSON.stringify({
+        taskId: 'leak',
+        model: 'outside-model',
+        status: 'complete',
+        briefing: 'outside secret briefing',
+        createdAt: '2026-03-05T00:00:00Z'
+      }));
+      fs.symlinkSync(outsideDir, path.join(sessionsDir, 'leak'), 'dir');
+
+      const { stdout, code } = await runCli(['list', '--cwd', tmpDir, '--json']);
+
+      expect(code).toBe(0);
+      const parsed = JSON.parse(stdout.trim());
+      expect(parsed.map(s => s.id)).toEqual(['valid-task']);
+      expect(stdout).not.toContain('outside secret briefing');
+      expect(stdout).not.toContain('outside-model');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -56,16 +56,19 @@ const { startSidecar, listSidecars, readSidecar, FOLD_MARKER, COMPLETE_MARKER } 
 describe('End-to-End Sidecar Flow', () => {
   let tmpDir;       // Project directory
   let tmpHomeDir;   // Mock home directory for Claude sessions
+  let originalAllowedRoots;
   let consoleSpy;
   let stdoutSpy;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    originalAllowedRoots = process.env.SIDECAR_ALLOWED_ROOTS;
 
     // Create temp directories for test using system temp dir
     const systemTmpDir = require('os').tmpdir();
     tmpDir = fs.mkdtempSync(path.join(systemTmpDir, 'sidecar-e2e-'));
     tmpHomeDir = fs.mkdtempSync(path.join(systemTmpDir, 'sidecar-home-'));
+    process.env.SIDECAR_ALLOWED_ROOTS = tmpDir;
 
     // Mock os.homedir to return our test home directory
     mockHomeDir = tmpHomeDir;
@@ -78,6 +81,11 @@ describe('End-to-End Sidecar Flow', () => {
   afterEach(() => {
     // Reset mock
     mockHomeDir = null;
+    if (originalAllowedRoots === undefined) {
+      delete process.env.SIDECAR_ALLOWED_ROOTS;
+    } else {
+      process.env.SIDECAR_ALLOWED_ROOTS = originalAllowedRoots;
+    }
 
     // Cleanup temp directories
     if (fs.existsSync(tmpDir)) {
@@ -393,7 +401,7 @@ ${FOLD_MARKER}`;
 
     it('should pass sessionDir through to context building', async () => {
       // Create session file in an explicit directory (simulating code-web)
-      const webSessionDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-web-'));
+      const webSessionDir = fs.mkdtempSync(path.join(tmpDir, 'sidecar-web-'));
       const sessionFile = path.join(webSessionDir, 'web-session.jsonl');
       fs.writeFileSync(sessionFile, JSON.stringify({
         type: 'user', message: { content: 'from web sandbox' }, timestamp: new Date().toISOString()

--- a/tests/headless-boundaries.test.js
+++ b/tests/headless-boundaries.test.js
@@ -96,4 +96,26 @@ describe('Headless session boundary containment', () => {
 
     expect(fs.existsSync(outsideTarget)).toBe(false);
   });
+
+  it('ignores a symlinked metadata abort signal outside the session directory', async () => {
+    const taskId = 'metadata-abort-escape';
+    const sessionDir = path.join(projectDir, '.claude', 'sidecar_sessions', taskId);
+    const outsideMetadata = path.join(outsideDir, 'metadata.json');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(outsideMetadata, JSON.stringify({ status: 'aborted' }));
+    fs.symlinkSync(outsideMetadata, path.join(sessionDir, 'metadata.json'));
+
+    const result = await runHeadless(
+      'test-model',
+      'system prompt',
+      'user message',
+      taskId,
+      projectDir,
+      5000
+    );
+
+    expect(result.aborted).toBe(false);
+    expect(result.completed).toBe(true);
+    expect(mockAbortSession).not.toHaveBeenCalled();
+  });
 });

--- a/tests/headless-boundaries.test.js
+++ b/tests/headless-boundaries.test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const mockCreateSession = jest.fn();
+const mockSendPromptAsync = jest.fn();
+const mockGetMessages = jest.fn();
+const mockCheckHealth = jest.fn();
+const mockStartServer = jest.fn();
+const mockServerClose = jest.fn();
+const mockAbortSession = jest.fn();
+
+jest.mock('../src/opencode-client', () => ({
+  createSession: mockCreateSession,
+  sendPromptAsync: mockSendPromptAsync,
+  getMessages: mockGetMessages,
+  checkHealth: mockCheckHealth,
+  startServer: mockStartServer,
+  abortSession: mockAbortSession
+}));
+
+jest.mock('../src/utils/logger', () => ({
+  logger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn()
+  }
+}));
+
+jest.mock('../src/utils/path-setup', () => ({
+  ensureNodeModulesBinInPath: jest.fn()
+}));
+
+jest.mock('../src/utils/server-setup', () => ({
+  ensurePortAvailable: jest.fn()
+}));
+
+jest.mock('../src/utils/idle-watchdog', () => ({
+  IdleWatchdog: class {
+    start() { return this; }
+    touch() {}
+    cancel() {}
+  }
+}));
+
+const { runHeadless, COMPLETE_MARKER } = require('../src/headless');
+
+describe('Headless session boundary containment', () => {
+  let projectDir;
+  let outsideDir;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headless-boundary-project-'));
+    outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'headless-boundary-outside-'));
+
+    mockCheckHealth.mockResolvedValue(true);
+    mockCreateSession.mockResolvedValue('opencode-session');
+    mockSendPromptAsync.mockResolvedValue(undefined);
+    mockGetMessages.mockResolvedValue([{
+      info: { role: 'assistant', id: 'msg-1', time: { completed: Date.now() } },
+      parts: [{ id: 'p1', type: 'text', text: COMPLETE_MARKER }]
+    }]);
+    mockStartServer.mockResolvedValue({
+      client: {},
+      server: {
+        url: 'http://127.0.0.1:4440',
+        close: mockServerClose
+      }
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  it('rejects a dangling conversation symlink before headless logging creates the outside target', async () => {
+    const taskId = 'dangling-headless';
+    const sessionDir = path.join(projectDir, '.claude', 'sidecar_sessions', taskId);
+    const outsideTarget = path.join(outsideDir, 'new-conversation.jsonl');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.symlinkSync(outsideTarget, path.join(sessionDir, 'conversation.jsonl'));
+
+    await expect(runHeadless(
+      'test-model',
+      'system prompt',
+      'user message',
+      taskId,
+      projectDir,
+      5000
+    )).rejects.toThrow(/symbolic link|session directory|outside/i);
+
+    expect(fs.existsSync(outsideTarget)).toBe(false);
+  });
+});

--- a/tests/headless.test.js
+++ b/tests/headless.test.js
@@ -5,6 +5,7 @@
  */
 
 const fs = require('fs');
+const path = require('path');
 
 // Mock fs
 jest.mock('fs', () => ({
@@ -44,6 +45,17 @@ jest.mock('../src/utils/logger', () => ({
   }
 }));
 
+const mockAppendContainedSessionFile = jest.fn();
+const mockEnsureSidecarSessionDir = jest.fn();
+const mockWriteContainedSessionFile = jest.fn();
+
+jest.mock('../src/utils/sidecar-session-boundaries', () => ({
+  appendContainedSessionFile: (...args) => mockAppendContainedSessionFile(...args),
+  ensureSidecarSessionDir: (...args) => mockEnsureSidecarSessionDir(...args),
+  writeContainedSessionFile: (...args) => mockWriteContainedSessionFile(...args),
+  resolveContainedSessionFile: jest.fn(() => null)
+}));
+
 const { runHeadless, extractSummary, COMPLETE_MARKER, FOLD_MARKER, formatFoldOutput, DEFAULT_TIMEOUT } = require('../src/headless');
 
 describe('Headless Mode Runner', () => {
@@ -52,6 +64,15 @@ describe('Headless Mode Runner', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockEnsureSidecarSessionDir.mockImplementation((project, taskId) =>
+      path.join(project, '.claude', 'sidecar_sessions', taskId)
+    );
+    mockAppendContainedSessionFile.mockImplementation((sessionDir, filename, data, options) => {
+      fs.appendFileSync(path.join(sessionDir, filename), data, options);
+    });
+    mockWriteContainedSessionFile.mockImplementation((sessionDir, filename, data, options) => {
+      fs.writeFileSync(path.join(sessionDir, filename), data, options);
+    });
 
     // Setup fs mocks
     fs.existsSync.mockReturnValue(true);
@@ -293,10 +314,7 @@ describe('Headless Mode Runner', () => {
 
         await runHeadless(testModel, testSystemPrompt, testUserMessage, testTaskId, testProject, 5000);
 
-        expect(fs.mkdirSync).toHaveBeenCalledWith(
-          expect.stringContaining(testTaskId),
-          { recursive: true, mode: 0o700 }
-        );
+        expect(mockEnsureSidecarSessionDir).toHaveBeenCalledWith(testProject, testTaskId);
       });
 
       it('should log system prompt as first message', async () => {

--- a/tests/headless.test.js
+++ b/tests/headless.test.js
@@ -47,11 +47,13 @@ jest.mock('../src/utils/logger', () => ({
 
 const mockAppendContainedSessionFile = jest.fn();
 const mockEnsureSidecarSessionDir = jest.fn();
+const mockReadContainedSessionFile = jest.fn();
 const mockWriteContainedSessionFile = jest.fn();
 
 jest.mock('../src/utils/sidecar-session-boundaries', () => ({
   appendContainedSessionFile: (...args) => mockAppendContainedSessionFile(...args),
   ensureSidecarSessionDir: (...args) => mockEnsureSidecarSessionDir(...args),
+  readContainedSessionFile: (...args) => mockReadContainedSessionFile(...args),
   writeContainedSessionFile: (...args) => mockWriteContainedSessionFile(...args),
   resolveContainedSessionFile: jest.fn(() => null)
 }));
@@ -67,6 +69,7 @@ describe('Headless Mode Runner', () => {
     mockEnsureSidecarSessionDir.mockImplementation((project, taskId) =>
       path.join(project, '.claude', 'sidecar_sessions', taskId)
     );
+    mockReadContainedSessionFile.mockReturnValue(null);
     mockAppendContainedSessionFile.mockImplementation((sessionDir, filename, data, options) => {
       fs.appendFileSync(path.join(sessionDir, filename), data, options);
     });
@@ -624,22 +627,11 @@ describe('Headless Mode Runner', () => {
         }]);
       });
 
-      // On second poll, simulate metadata.status = 'aborted'
-      const originalReadFileSync = fs.readFileSync;
-      fs.readFileSync = jest.fn((filePath, encoding) => {
-        if (typeof filePath === 'string' && filePath.includes('metadata.json') && pollCount >= 2) {
+      mockReadContainedSessionFile.mockImplementation((_sessionDir, filename) => {
+        if (filename === 'metadata.json' && pollCount >= 2) {
           return JSON.stringify({ status: 'aborted' });
         }
-        // For other reads, return empty string
-        return '';
-      });
-
-      // existsSync should return true for metadata check
-      fs.existsSync.mockImplementation((p) => {
-        if (typeof p === 'string' && p.includes('metadata.json')) {
-          return pollCount >= 2;
-        }
-        return true;
+        return null;
       });
 
       const result = await runHeadless(
@@ -650,9 +642,6 @@ describe('Headless Mode Runner', () => {
       // Should have detected external abort
       expect(result.aborted).toBe(true);
       expect(mockServerClose).toHaveBeenCalled();
-
-      // Restore
-      fs.readFileSync = originalReadFileSync;
     }, 15000);
   });
 

--- a/tests/mcp-codex-subagents.test.js
+++ b/tests/mcp-codex-subagents.test.js
@@ -7,10 +7,25 @@ const path = require('path');
 describe('codex subagent MCP handlers', () => {
   let tempDir;
   let projectDir;
+  let canonicalProjectDir;
+
+  function createParentSession(taskId = 'parent123') {
+    const parentDir = path.join(projectDir, '.claude', 'sidecar_sessions', taskId);
+    fs.mkdirSync(parentDir, { recursive: true });
+    fs.writeFileSync(path.join(parentDir, 'metadata.json'), JSON.stringify({
+      taskId,
+      project: canonicalProjectDir,
+      projectDir: canonicalProjectDir,
+      status: 'running',
+      createdAt: new Date().toISOString()
+    }));
+    return parentDir;
+  }
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-codex-subagent-'));
     projectDir = tempDir;
+    canonicalProjectDir = fs.realpathSync(projectDir);
     jest.resetModules();
     jest.clearAllMocks();
   });
@@ -28,13 +43,7 @@ describe('codex subagent MCP handlers', () => {
         startCodexSubagent: runnerMock
       }));
 
-      const parentDir = path.join(projectDir, '.claude', 'sidecar_sessions', 'parent123');
-      fs.mkdirSync(parentDir, { recursive: true });
-      fs.writeFileSync(path.join(parentDir, 'metadata.json'), JSON.stringify({
-        taskId: 'parent123',
-        status: 'running',
-        createdAt: new Date().toISOString()
-      }));
+      createParentSession('parent123');
 
       const { handlers } = require('../src/mcp-server');
       const result = await handlers.sidecar_subagent_start({
@@ -49,7 +58,7 @@ describe('codex subagent MCP handlers', () => {
       expect(parsed.status).toBe('running');
       expect(parsed.backend).toBe('codex');
       expect(runnerMock).toHaveBeenCalledWith(expect.objectContaining({
-        projectDir,
+        projectDir: canonicalProjectDir,
         parentTaskId: 'parent123',
         briefing: 'Inspect auth flow',
         agentType: 'explore'
@@ -58,6 +67,7 @@ describe('codex subagent MCP handlers', () => {
   });
 
   test('status reads subagent progress from the subagent directory', async () => {
+    createParentSession('parent123');
     const subagentDir = path.join(
       projectDir, '.claude', 'sidecar_sessions', 'parent123', 'subagents', 'sub1'
     );
@@ -94,6 +104,7 @@ describe('codex subagent MCP handlers', () => {
   });
 
   test('read returns summary by default', async () => {
+    createParentSession('parent123');
     const subagentDir = path.join(
       projectDir, '.claude', 'sidecar_sessions', 'parent123', 'subagents', 'sub2'
     );
@@ -119,6 +130,7 @@ describe('codex subagent MCP handlers', () => {
 
   test('abort marks subagent aborted and terminates pid', async () => {
     const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => true);
+    createParentSession('parent123');
     const subagentDir = path.join(
       projectDir, '.claude', 'sidecar_sessions', 'parent123', 'subagents', 'sub3'
     );

--- a/tests/mcp-codex-subagents.test.js
+++ b/tests/mcp-codex-subagents.test.js
@@ -177,6 +177,36 @@ describe('codex subagent MCP handlers', () => {
     expect(result.content[0].text).toContain('Updated auth validation.');
   });
 
+  test('read rejects a symlinked subagent directory before reading outside summary', async () => {
+    createParentSession('parent123');
+    const subagentsRoot = path.join(
+      projectDir, '.claude', 'sidecar_sessions', 'parent123', 'subagents'
+    );
+    const outsideDir = path.join(tempDir, 'outside-subagent');
+    fs.mkdirSync(subagentsRoot, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(path.join(outsideDir, 'metadata.json'), JSON.stringify({
+      subagentId: 'sub1',
+      parentTaskId: 'parent123',
+      agentType: 'general',
+      backend: 'codex',
+      status: 'complete',
+      createdAt: new Date().toISOString()
+    }));
+    fs.writeFileSync(path.join(outsideDir, 'summary.md'), 'outside secret summary');
+    fs.symlinkSync(outsideDir, path.join(subagentsRoot, 'sub1'), 'dir');
+
+    const { handlers } = require('../src/mcp-server');
+    const result = await handlers.sidecar_subagent_read({
+      parentTaskId: 'parent123',
+      subagentId: 'sub1'
+    }, projectDir);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/outside|subagent|session/i);
+    expect(result.content[0].text).not.toContain('outside secret summary');
+  });
+
   test('abort marks subagent aborted and terminates pid', async () => {
     const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => true);
     createParentSession('parent123');
@@ -207,5 +237,39 @@ describe('codex subagent MCP handlers', () => {
     const metadata = JSON.parse(fs.readFileSync(path.join(subagentDir, 'metadata.json'), 'utf-8'));
     expect(metadata.status).toBe('aborted');
     expect(metadata.pid).toBeNull();
+  });
+
+  test('abort rejects a symlinked subagent directory before writing outside metadata or signaling pid', async () => {
+    const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => true);
+    createParentSession('parent123');
+    const subagentsRoot = path.join(
+      projectDir, '.claude', 'sidecar_sessions', 'parent123', 'subagents'
+    );
+    const outsideDir = path.join(tempDir, 'outside-running-subagent');
+    fs.mkdirSync(subagentsRoot, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(path.join(outsideDir, 'metadata.json'), JSON.stringify({
+      subagentId: 'sub4',
+      parentTaskId: 'parent123',
+      agentType: 'general',
+      backend: 'codex',
+      status: 'running',
+      pid: 43210,
+      createdAt: new Date().toISOString()
+    }));
+    fs.symlinkSync(outsideDir, path.join(subagentsRoot, 'sub4'), 'dir');
+
+    const { handlers } = require('../src/mcp-server');
+    const result = await handlers.sidecar_subagent_abort({
+      parentTaskId: 'parent123',
+      subagentId: 'sub4'
+    }, projectDir);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/outside|subagent|session/i);
+    expect(killSpy).not.toHaveBeenCalled();
+    const metadata = JSON.parse(fs.readFileSync(path.join(outsideDir, 'metadata.json'), 'utf-8'));
+    expect(metadata.status).toBe('running');
+    expect(metadata.pid).toBe(43210);
   });
 });

--- a/tests/mcp-codex-subagents.test.js
+++ b/tests/mcp-codex-subagents.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+describe('codex subagent MCP handlers', () => {
+  let tempDir;
+  let projectDir;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-codex-subagent-'));
+    projectDir = tempDir;
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  test('start returns subagentId and running status', async () => {
+    const runnerMock = jest.fn();
+
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('../src/subagents/codex-runner', () => ({
+        startCodexSubagent: runnerMock
+      }));
+
+      const parentDir = path.join(projectDir, '.claude', 'sidecar_sessions', 'parent123');
+      fs.mkdirSync(parentDir, { recursive: true });
+      fs.writeFileSync(path.join(parentDir, 'metadata.json'), JSON.stringify({
+        taskId: 'parent123',
+        status: 'running',
+        createdAt: new Date().toISOString()
+      }));
+
+      const { handlers } = require('../src/mcp-server');
+      const result = await handlers.sidecar_subagent_start({
+        parentTaskId: 'parent123',
+        prompt: 'Inspect auth flow',
+        agentType: 'explore'
+      }, projectDir);
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.parentTaskId).toBe('parent123');
+      expect(parsed.subagentId).toBeTruthy();
+      expect(parsed.status).toBe('running');
+      expect(parsed.backend).toBe('codex');
+      expect(runnerMock).toHaveBeenCalledWith(expect.objectContaining({
+        projectDir,
+        parentTaskId: 'parent123',
+        briefing: 'Inspect auth flow',
+        agentType: 'explore'
+      }));
+    });
+  });
+
+  test('status reads subagent progress from the subagent directory', async () => {
+    const subagentDir = path.join(
+      projectDir, '.claude', 'sidecar_sessions', 'parent123', 'subagents', 'sub1'
+    );
+    fs.mkdirSync(subagentDir, { recursive: true });
+    fs.writeFileSync(path.join(subagentDir, 'metadata.json'), JSON.stringify({
+      subagentId: 'sub1',
+      parentTaskId: 'parent123',
+      agentType: 'plan',
+      backend: 'codex',
+      status: 'running',
+      createdAt: new Date().toISOString()
+    }));
+    fs.writeFileSync(path.join(subagentDir, 'conversation.jsonl'),
+      '{"role":"assistant","content":"Scanning files"}\n');
+    fs.writeFileSync(path.join(subagentDir, 'progress.json'), JSON.stringify({
+      stage: 'receiving',
+      stageLabel: 'Codex is generating a response...',
+      updatedAt: new Date().toISOString()
+    }));
+
+    const { handlers } = require('../src/mcp-server');
+    const result = await handlers.sidecar_subagent_status({
+      parentTaskId: 'parent123',
+      subagentId: 'sub1'
+    }, projectDir);
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.parentTaskId).toBe('parent123');
+    expect(parsed.subagentId).toBe('sub1');
+    expect(parsed.status).toBe('running');
+    expect(parsed.backend).toBe('codex');
+    expect(parsed.stage).toBe('receiving');
+    expect(parsed.latest).toContain('Scanning files');
+  });
+
+  test('read returns summary by default', async () => {
+    const subagentDir = path.join(
+      projectDir, '.claude', 'sidecar_sessions', 'parent123', 'subagents', 'sub2'
+    );
+    fs.mkdirSync(subagentDir, { recursive: true });
+    fs.writeFileSync(path.join(subagentDir, 'metadata.json'), JSON.stringify({
+      subagentId: 'sub2',
+      parentTaskId: 'parent123',
+      agentType: 'build',
+      backend: 'codex',
+      status: 'complete',
+      createdAt: new Date().toISOString()
+    }));
+    fs.writeFileSync(path.join(subagentDir, 'summary.md'), 'Updated auth validation.');
+
+    const { handlers } = require('../src/mcp-server');
+    const result = await handlers.sidecar_subagent_read({
+      parentTaskId: 'parent123',
+      subagentId: 'sub2'
+    }, projectDir);
+
+    expect(result.content[0].text).toContain('Updated auth validation.');
+  });
+
+  test('abort marks subagent aborted and terminates pid', async () => {
+    const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => true);
+    const subagentDir = path.join(
+      projectDir, '.claude', 'sidecar_sessions', 'parent123', 'subagents', 'sub3'
+    );
+    fs.mkdirSync(subagentDir, { recursive: true });
+    fs.writeFileSync(path.join(subagentDir, 'metadata.json'), JSON.stringify({
+      subagentId: 'sub3',
+      parentTaskId: 'parent123',
+      agentType: 'general',
+      backend: 'codex',
+      status: 'running',
+      pid: 43210,
+      createdAt: new Date().toISOString()
+    }));
+
+    const { handlers } = require('../src/mcp-server');
+    const result = await handlers.sidecar_subagent_abort({
+      parentTaskId: 'parent123',
+      subagentId: 'sub3'
+    }, projectDir);
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.status).toBe('aborted');
+    expect(killSpy).toHaveBeenCalledWith(43210, 'SIGTERM');
+
+    const metadata = JSON.parse(fs.readFileSync(path.join(subagentDir, 'metadata.json'), 'utf-8'));
+    expect(metadata.status).toBe('aborted');
+    expect(metadata.pid).toBeNull();
+  });
+});

--- a/tests/mcp-codex-subagents.test.js
+++ b/tests/mcp-codex-subagents.test.js
@@ -22,6 +22,35 @@ describe('codex subagent MCP handlers', () => {
     return parentDir;
   }
 
+  function createParentSessionWithoutProject(taskId = 'parent123') {
+    const parentDir = path.join(projectDir, '.claude', 'sidecar_sessions', taskId);
+    fs.mkdirSync(parentDir, { recursive: true });
+    fs.writeFileSync(path.join(parentDir, 'metadata.json'), JSON.stringify({
+      taskId,
+      status: 'running',
+      createdAt: new Date().toISOString()
+    }));
+    return parentDir;
+  }
+
+  function createSubagentSession(parentTaskId, subagentId, status = 'running') {
+    const subagentDir = path.join(
+      projectDir, '.claude', 'sidecar_sessions', parentTaskId, 'subagents', subagentId
+    );
+    fs.mkdirSync(subagentDir, { recursive: true });
+    fs.writeFileSync(path.join(subagentDir, 'metadata.json'), JSON.stringify({
+      subagentId,
+      parentTaskId,
+      agentType: 'general',
+      backend: 'codex',
+      status,
+      pid: status === 'running' ? 43210 : null,
+      createdAt: new Date().toISOString()
+    }));
+    fs.writeFileSync(path.join(subagentDir, 'summary.md'), 'Updated auth validation.');
+    return subagentDir;
+  }
+
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-codex-subagent-'));
     projectDir = tempDir;
@@ -63,6 +92,26 @@ describe('codex subagent MCP handlers', () => {
         briefing: 'Inspect auth flow',
         agentType: 'explore'
       }));
+    });
+  });
+
+  test.each([
+    ['sidecar_subagent_start', { parentTaskId: 'parent123', prompt: 'Inspect auth flow', agentType: 'explore' }],
+    ['sidecar_subagent_status', { parentTaskId: 'parent123', subagentId: 'sub1' }],
+    ['sidecar_subagent_read', { parentTaskId: 'parent123', subagentId: 'sub1' }],
+    ['sidecar_subagent_abort', { parentTaskId: 'parent123', subagentId: 'sub1' }]
+  ])('%s rejects parent metadata without project binding', async (handlerName, input) => {
+    createParentSessionWithoutProject('parent123');
+    if (handlerName !== 'sidecar_subagent_start') {
+      createSubagentSession('parent123', 'sub1');
+    }
+
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('../src/subagents/codex-runner', () => ({
+        startCodexSubagent: jest.fn()
+      }));
+      const { handlers } = require('../src/mcp-server');
+      await expect(handlers[handlerName](input, projectDir)).rejects.toThrow(/project binding/i);
     });
   });
 

--- a/tests/mcp-project-dir.test.js
+++ b/tests/mcp-project-dir.test.js
@@ -3,14 +3,22 @@ const fs = require('fs');
 const path = require('path');
 
 describe('getProjectDir', () => {
+  const repoRoot = fs.realpathSync(path.resolve(__dirname, '..'));
+  let originalEnv;
+
   beforeEach(() => {
+    originalEnv = { ...process.env };
     jest.resetModules();
   });
 
-  test('returns explicit project path when valid directory', () => {
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  test('returns explicit project path when it is under the current repo root', () => {
     const { getProjectDir } = require('../src/mcp-server');
-    const result = getProjectDir(os.tmpdir());
-    expect(result).toBe(os.tmpdir());
+    const result = getProjectDir(path.join(repoRoot, 'src'));
+    expect(result).toBe(fs.realpathSync(path.join(repoRoot, 'src')));
   });
 
   test('ignores explicit project path when directory does not exist', () => {
@@ -19,40 +27,43 @@ describe('getProjectDir', () => {
     expect(result).not.toBe('/nonexistent/path/that/does/not/exist');
   });
 
-  test('falls back to $HOME when cwd is root /', () => {
+  test('rejects cwd root instead of falling back to $HOME', () => {
     const originalCwd = process.cwd;
     process.cwd = () => '/';
     try {
       jest.resetModules();
       const { getProjectDir } = require('../src/mcp-server');
-      const result = getProjectDir();
-      expect(result).toBe(os.homedir());
+      expect(() => getProjectDir()).toThrow(/unsafe/i);
     } finally {
       process.cwd = originalCwd;
     }
   });
 
-  test('uses cwd when it is a valid writable directory', () => {
+  test('uses cwd when it is the current repo root', () => {
     const originalCwd = process.cwd;
-    process.cwd = () => os.tmpdir();
+    process.cwd = () => repoRoot;
     try {
       jest.resetModules();
       const { getProjectDir } = require('../src/mcp-server');
       const result = getProjectDir();
-      expect(result).toBe(os.tmpdir());
+      expect(result).toBe(repoRoot);
     } finally {
       process.cwd = originalCwd;
     }
   });
 
-  test('returns $HOME when no explicit project and cwd is root', () => {
+  test('rejects $HOME by default', () => {
+    const { getProjectDir } = require('../src/mcp-server');
+    expect(() => getProjectDir(os.homedir())).toThrow(/unsafe|not allowed/i);
+  });
+
+  test('rejects root when no explicit project and cwd is root', () => {
     const originalCwd = process.cwd;
     process.cwd = () => '/';
     try {
       jest.resetModules();
       const { getProjectDir } = require('../src/mcp-server');
-      const result = getProjectDir(undefined);
-      expect(result).toBe(os.homedir());
+      expect(() => getProjectDir(undefined)).toThrow(/unsafe/i);
     } finally {
       process.cwd = originalCwd;
     }
@@ -62,6 +73,8 @@ describe('getProjectDir', () => {
 describe('MCP handler dispatch passes input.project', () => {
   test('sidecar_list uses input.project when provided', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-proj-'));
+    const originalAllowedRoots = process.env.SIDECAR_ALLOWED_ROOTS;
+    process.env.SIDECAR_ALLOWED_ROOTS = tmpDir;
     const sessDir = path.join(tmpDir, '.claude', 'sidecar_sessions', 'test1');
     fs.mkdirSync(sessDir, { recursive: true });
     fs.writeFileSync(path.join(sessDir, 'metadata.json'), JSON.stringify({
@@ -77,12 +90,15 @@ describe('MCP handler dispatch passes input.project', () => {
       expect(parsed).toHaveLength(1);
       expect(parsed[0].id).toBe('test1');
     } finally {
+      process.env.SIDECAR_ALLOWED_ROOTS = originalAllowedRoots;
       fs.rmSync(tmpDir, { recursive: true });
     }
   });
 
   test('sidecar_status uses input.project when no 2nd arg', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-proj-'));
+    const originalAllowedRoots = process.env.SIDECAR_ALLOWED_ROOTS;
+    process.env.SIDECAR_ALLOWED_ROOTS = tmpDir;
     const sessDir = path.join(tmpDir, '.claude', 'sidecar_sessions', 'stat1');
     fs.mkdirSync(sessDir, { recursive: true });
     fs.writeFileSync(path.join(sessDir, 'metadata.json'), JSON.stringify({
@@ -97,6 +113,7 @@ describe('MCP handler dispatch passes input.project', () => {
       expect(parsed.taskId).toBe('stat1');
       expect(parsed.status).toBe('running');
     } finally {
+      process.env.SIDECAR_ALLOWED_ROOTS = originalAllowedRoots;
       fs.rmSync(tmpDir, { recursive: true });
     }
   });

--- a/tests/mcp-protocol.integration.test.js
+++ b/tests/mcp-protocol.integration.test.js
@@ -17,6 +17,8 @@ const EXPECTED_TOOLS = [
   'sidecar_start', 'sidecar_status', 'sidecar_read',
   'sidecar_list', 'sidecar_resume', 'sidecar_continue',
   'sidecar_setup', 'sidecar_guide', 'sidecar_abort',
+  'sidecar_subagent_start', 'sidecar_subagent_status',
+  'sidecar_subagent_read', 'sidecar_subagent_abort',
 ];
 
 /**
@@ -136,7 +138,7 @@ describe('MCP Protocol: handshake and tool discovery', () => {
     }
   });
 
-  it('lists all 9 sidecar tools via tools/list', async () => {
+  it('lists all 13 sidecar tools via tools/list', async () => {
     const result = await client.request('tools/list', {});
     expect(result.result).toBeDefined();
     const toolNames = result.result.tools.map(t => t.name);

--- a/tests/mcp-security.test.js
+++ b/tests/mcp-security.test.js
@@ -166,6 +166,100 @@ describe('sidecar workspace boundaries', () => {
       fs.rmSync(tmpProject, { recursive: true, force: true });
     }
   });
+
+  test('validateSubagentLaunchProject rejects symlinked parent sessions outside the project sessions root', () => {
+    const tmpProject = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-subagent-project-'));
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-subagent-outside-'));
+    const parentTaskId = 'parent-task';
+    const sessionsRoot = path.join(tmpProject, '.claude', 'sidecar_sessions');
+    const parentLink = path.join(sessionsRoot, parentTaskId);
+    const outsideParent = path.join(outsideDir, 'outside-session');
+
+    try {
+      fs.mkdirSync(sessionsRoot, { recursive: true });
+      fs.mkdirSync(outsideParent, { recursive: true });
+      fs.writeFileSync(path.join(outsideParent, 'metadata.json'), JSON.stringify({
+        taskId: parentTaskId,
+        project: fs.realpathSync(tmpProject),
+        projectDir: fs.realpathSync(tmpProject),
+        status: 'running'
+      }));
+      fs.symlinkSync(outsideParent, parentLink, 'dir');
+
+      expect(() => validateSubagentLaunchProject({
+        projectDir: tmpProject,
+        parentTaskId,
+        getSession: (_projectDir, taskId) => JSON.parse(fs.readFileSync(
+          path.join(tmpProject, '.claude', 'sidecar_sessions', taskId, 'metadata.json'),
+          'utf-8'
+        )),
+        getSessionDir: (_projectDir, taskId) => path.join(
+          tmpProject, '.claude', 'sidecar_sessions', taskId
+        )
+      })).toThrow(/outside|session root/i);
+    } finally {
+      fs.rmSync(tmpProject, { recursive: true, force: true });
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('sidecar MCP handler boundaries', () => {
+  let tmpProject;
+  let outsideDir;
+
+  beforeEach(() => {
+    tmpProject = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-mcp-project-'));
+    outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-mcp-outside-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpProject, { recursive: true, force: true });
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  function linkOutsideSession(metadata) {
+    const sessionsRoot = path.join(tmpProject, '.claude', 'sidecar_sessions');
+    const outsideSession = path.join(outsideDir, 'outside-session');
+    fs.mkdirSync(sessionsRoot, { recursive: true });
+    fs.mkdirSync(outsideSession, { recursive: true });
+    fs.writeFileSync(path.join(outsideSession, 'metadata.json'), JSON.stringify(metadata));
+    fs.writeFileSync(path.join(outsideSession, 'summary.md'), 'external secret summary');
+    fs.writeFileSync(path.join(outsideSession, 'conversation.jsonl'), 'external secret conversation\n');
+    fs.symlinkSync(outsideSession, path.join(sessionsRoot, 'leak'), 'dir');
+    return outsideSession;
+  }
+
+  test('sidecar_read rejects a task directory symlink before reading outside content', async () => {
+    linkOutsideSession({ taskId: 'leak', status: 'complete' });
+
+    const { handlers } = require('../src/mcp-server');
+    const result = await handlers.sidecar_read({ taskId: 'leak' }, tmpProject);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/outside|session root/i);
+    expect(result.content[0].text).not.toContain('external secret summary');
+  });
+
+  test('sidecar_abort rejects a task directory symlink before signaling the outside pid', async () => {
+    const outsideSession = linkOutsideSession({
+      taskId: 'leak',
+      status: 'running',
+      pid: 424242,
+      createdAt: new Date().toISOString()
+    });
+    const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => {});
+
+    const { handlers } = require('../src/mcp-server');
+    const result = await handlers.sidecar_abort({ taskId: 'leak' }, tmpProject);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/outside|session root/i);
+    expect(killSpy).not.toHaveBeenCalled();
+    const outsideMetadata = JSON.parse(fs.readFileSync(path.join(outsideSession, 'metadata.json'), 'utf-8'));
+    expect(outsideMetadata.status).toBe('running');
+  });
 });
 
 describe('sidecar context boundaries', () => {

--- a/tests/mcp-security.test.js
+++ b/tests/mcp-security.test.js
@@ -3,11 +3,13 @@ const os = require('os');
 const path = require('path');
 
 const {
+  assertContextBinding,
   parseAllowedRoots,
   validateProjectPath,
   validateSessionDir,
   validateSubagentParent,
-  defaultIncludeContext
+  defaultIncludeContext,
+  validateSubagentLaunchProject
 } = require('../src/utils/sidecar-boundaries');
 const { buildContext } = require('../src/sidecar/context-builder');
 const { saveApiKey } = require('../src/utils/api-key-store');
@@ -36,6 +38,47 @@ describe('sidecar workspace boundaries', () => {
     })).toBe(expected);
   });
 
+  test('validateProjectPath rejects descendants when cwd is root unless explicitly allowed', () => {
+    expect(() => validateProjectPath(repoRoot, {
+      cwd: '/',
+      allowedRoots: []
+    })).toThrow(/not allowed|unsafe/i);
+
+    expect(validateProjectPath(repoRoot, {
+      cwd: '/',
+      allowedRoots: [repoRoot]
+    })).toBe(repoRoot);
+  });
+
+  test('validateProjectPath rejects descendants when cwd is home unless explicitly allowed', () => {
+    const homeDir = fs.realpathSync(os.homedir());
+    if (!repoRoot.startsWith(homeDir + path.sep)) {
+      return;
+    }
+
+    expect(() => validateProjectPath(repoRoot, {
+      cwd: homeDir,
+      allowedRoots: []
+    })).toThrow(/not allowed|unsafe/i);
+  });
+
+  test('validateProjectPath allows broad cwd descendants with unsafe override only', () => {
+    const original = process.env.SIDECAR_ALLOW_UNSAFE_PROJECT;
+    try {
+      process.env.SIDECAR_ALLOW_UNSAFE_PROJECT = '1';
+      expect(validateProjectPath(repoRoot, {
+        cwd: '/',
+        allowedRoots: []
+      })).toBe(repoRoot);
+    } finally {
+      if (original === undefined) {
+        delete process.env.SIDECAR_ALLOW_UNSAFE_PROJECT;
+      } else {
+        process.env.SIDECAR_ALLOW_UNSAFE_PROJECT = original;
+      }
+    }
+  });
+
   test('validateProjectPath rejects a symlink inside an allowed root resolving outside that root', () => {
     const allowedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-allowed-'));
     const outsideRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-outside-'));
@@ -57,6 +100,38 @@ describe('sidecar workspace boundaries', () => {
   test('defaultIncludeContext returns false', () => {
     expect(defaultIncludeContext()).toBe(false);
   });
+
+  test('includeContext rejects missing, default, or current session bindings', () => {
+    expect(() => assertContextBinding({})).toThrow(/includeContext/i);
+    expect(() => assertContextBinding({ session: 'current' })).toThrow(/exact/i);
+    expect(() => assertContextBinding({ sessionId: 'current' })).toThrow(/exact/i);
+    expect(() => assertContextBinding({ parentSession: 'current' })).toThrow(/exact/i);
+  });
+
+  test('includeContext accepts exact session, sessionDir, or coworkProcess bindings', () => {
+    expect(() => assertContextBinding({ session: 'session-a' })).not.toThrow();
+    expect(() => assertContextBinding({ sessionDir: path.join(repoRoot, '.claude', 'sidecar_sessions', 'session-a') })).not.toThrow();
+    expect(() => assertContextBinding({ client: 'cowork', coworkProcess: 'exact-process' })).not.toThrow();
+  });
+
+  test('validateSubagentLaunchProject rejects parent directories without metadata', () => {
+    const tmpProject = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-subagent-parent-'));
+    const parentTaskId = 'parent-task';
+    const parentDir = path.join(tmpProject, '.claude', 'sidecar_sessions', parentTaskId);
+
+    try {
+      fs.mkdirSync(parentDir, { recursive: true });
+
+      expect(() => validateSubagentLaunchProject({
+        projectDir: tmpProject,
+        parentTaskId,
+        getSession: () => null,
+        getSessionDir: () => parentDir
+      })).toThrow(/metadata|parent session/i);
+    } finally {
+      fs.rmSync(tmpProject, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('sidecar context boundaries', () => {
@@ -66,6 +141,24 @@ describe('sidecar context boundaries', () => {
     expect(() => buildContext('/other/project', 'session-a', {
       parentProject: repoRoot
     })).toThrow(/project/i);
+  });
+
+  test('buildContext rejects explicit code-web sessionDir outside the project root', () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-codeweb-project-'));
+    const externalSessionDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-codeweb-session-'));
+
+    try {
+      fs.writeFileSync(path.join(externalSessionDir, 'session-a.jsonl'), '');
+
+      expect(() => buildContext(projectRoot, 'session-a', {
+        client: 'code-web',
+        sessionDir: externalSessionDir,
+        parentProject: projectRoot
+      })).toThrow(/outside|project root/i);
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+      fs.rmSync(externalSessionDir, { recursive: true, force: true });
+    }
   });
 
   test('validateSessionDir rejects session directories outside the project root', () => {

--- a/tests/mcp-security.test.js
+++ b/tests/mcp-security.test.js
@@ -106,11 +106,19 @@ describe('sidecar workspace boundaries', () => {
     expect(() => assertContextBinding({ session: 'current' })).toThrow(/exact/i);
     expect(() => assertContextBinding({ sessionId: 'current' })).toThrow(/exact/i);
     expect(() => assertContextBinding({ parentSession: 'current' })).toThrow(/exact/i);
+    expect(() => assertContextBinding({ sessionDir: path.join(repoRoot, '.claude', 'sidecar_sessions') })).toThrow(/exact/i);
+    expect(() => assertContextBinding({
+      session: 'current',
+      sessionDir: path.join(repoRoot, '.claude', 'sidecar_sessions')
+    })).toThrow(/exact/i);
   });
 
-  test('includeContext accepts exact session, sessionDir, or coworkProcess bindings', () => {
+  test('includeContext accepts exact session, exact session plus sessionDir, or coworkProcess bindings', () => {
     expect(() => assertContextBinding({ session: 'session-a' })).not.toThrow();
-    expect(() => assertContextBinding({ sessionDir: path.join(repoRoot, '.claude', 'sidecar_sessions', 'session-a') })).not.toThrow();
+    expect(() => assertContextBinding({
+      session: 'session-a',
+      sessionDir: path.join(repoRoot, '.claude', 'sidecar_sessions')
+    })).not.toThrow();
     expect(() => assertContextBinding({ client: 'cowork', coworkProcess: 'exact-process' })).not.toThrow();
   });
 

--- a/tests/mcp-security.test.js
+++ b/tests/mcp-security.test.js
@@ -260,6 +260,91 @@ describe('sidecar MCP handler boundaries', () => {
     const outsideMetadata = JSON.parse(fs.readFileSync(path.join(outsideSession, 'metadata.json'), 'utf-8'));
     expect(outsideMetadata.status).toBe('running');
   });
+
+  test('sidecar_start rejects a symlinked sessions root before spawning or writing outside metadata', async () => {
+    const originalSharedServer = process.env.SIDECAR_SHARED_SERVER;
+    const claudeDir = path.join(tmpProject, '.claude');
+    const outsideRoot = path.join(outsideDir, 'outside-sessions-root');
+    let spawnMock;
+
+    try {
+      process.env.SIDECAR_SHARED_SERVER = '0';
+      fs.mkdirSync(claudeDir, { recursive: true });
+      fs.mkdirSync(outsideRoot, { recursive: true });
+      fs.symlinkSync(outsideRoot, path.join(claudeDir, 'sidecar_sessions'), 'dir');
+
+      await jest.isolateModulesAsync(async () => {
+        jest.doMock('child_process', () => ({
+          spawn: jest.fn(() => ({ pid: 12345, unref: jest.fn() })),
+        }));
+        jest.doMock('../src/sidecar/start', () => ({
+          generateTaskId: jest.fn(() => 'root-escape')
+        }));
+
+        const { handlers } = require('../src/mcp-server');
+        const result = await handlers.sidecar_start({
+          prompt: 'test task',
+          noUi: true,
+          model: 'google/gemini-test'
+        }, tmpProject);
+        spawnMock = require('child_process').spawn;
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toMatch(/sidecar sessions root|symbolic link|outside/i);
+      });
+
+      expect(spawnMock).not.toHaveBeenCalled();
+      expect(fs.existsSync(path.join(outsideRoot, 'root-escape', 'metadata.json'))).toBe(false);
+    } finally {
+      if (originalSharedServer === undefined) {
+        delete process.env.SIDECAR_SHARED_SERVER;
+      } else {
+        process.env.SIDECAR_SHARED_SERVER = originalSharedServer;
+      }
+    }
+  });
+
+  test('sidecar_continue rejects a preexisting symlinked new task directory before stderr capture', async () => {
+    const originalSharedServer = process.env.SIDECAR_SHARED_SERVER;
+    const sessionsRoot = path.join(tmpProject, '.claude', 'sidecar_sessions');
+    const outsideSession = path.join(outsideDir, 'outside-new-session');
+    let spawnMock;
+
+    try {
+      process.env.SIDECAR_SHARED_SERVER = '0';
+      fs.mkdirSync(sessionsRoot, { recursive: true });
+      fs.mkdirSync(outsideSession, { recursive: true });
+      fs.symlinkSync(outsideSession, path.join(sessionsRoot, 'new-task'), 'dir');
+
+      await jest.isolateModulesAsync(async () => {
+        jest.doMock('child_process', () => ({
+          spawn: jest.fn(() => ({ pid: 12345, unref: jest.fn() })),
+        }));
+        jest.doMock('../src/sidecar/start', () => ({
+          generateTaskId: jest.fn(() => 'new-task')
+        }));
+
+        const { handlers } = require('../src/mcp-server');
+        const result = await handlers.sidecar_continue({
+          taskId: 'old-task',
+          prompt: 'follow up'
+        }, tmpProject);
+        spawnMock = require('child_process').spawn;
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toMatch(/session directory|symbolic link|outside/i);
+      });
+
+      expect(spawnMock).not.toHaveBeenCalled();
+      expect(fs.existsSync(path.join(outsideSession, 'debug.log'))).toBe(false);
+    } finally {
+      if (originalSharedServer === undefined) {
+        delete process.env.SIDECAR_SHARED_SERVER;
+      } else {
+        process.env.SIDECAR_SHARED_SERVER = originalSharedServer;
+      }
+    }
+  });
 });
 
 describe('sidecar context boundaries', () => {

--- a/tests/mcp-security.test.js
+++ b/tests/mcp-security.test.js
@@ -9,6 +9,7 @@ const {
   validateSessionDir,
   validateSubagentParent,
   defaultIncludeContext,
+  resolveExactSessionFile,
   validateSubagentLaunchProject
 } = require('../src/utils/sidecar-boundaries');
 const { buildContext } = require('../src/sidecar/context-builder');
@@ -27,6 +28,31 @@ describe('sidecar workspace boundaries', () => {
     expect(() => validateProjectPath('/tmp', options)).toThrow(/not allowed|unsafe/i);
     expect(() => validateProjectPath('/', options)).toThrow(/not allowed|unsafe/i);
     expect(() => validateProjectPath(os.homedir(), options)).toThrow(/not allowed|unsafe/i);
+  });
+
+  test('validateProjectPath rejects broad user and volume roots by default', () => {
+    for (const broadRoot of ['/Users', '/Volumes']) {
+      if (!fs.existsSync(broadRoot)) {
+        continue;
+      }
+
+      expect(() => validateProjectPath(broadRoot, {
+        cwd: repoRoot,
+        allowedRoots: [broadRoot]
+      })).toThrow(/not allowed|unsafe|broad/i);
+    }
+  });
+
+  test('validateProjectPath does not let a broad parent root authorize descendants', () => {
+    const usersRoot = '/Users';
+    if (!fs.existsSync(usersRoot) || !repoRoot.startsWith(`${usersRoot}${path.sep}`)) {
+      return;
+    }
+
+    expect(() => validateProjectPath(repoRoot, {
+      cwd: usersRoot,
+      allowedRoots: [usersRoot]
+    })).toThrow(/not allowed|unsafe|broad/i);
   });
 
   test('validateProjectPath accepts and canonicalizes a descendant of the repo root', () => {
@@ -174,6 +200,36 @@ describe('sidecar context boundaries', () => {
       path.join('/other/project', '.claude', 'sidecar_sessions', 'session-a'),
       repoRoot
     )).toThrow(/project|outside/i);
+  });
+
+  test('resolveExactSessionFile rejects symlinked session files that escape the session directory', () => {
+    const sessionDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-exact-session-'));
+    const externalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-exact-outside-'));
+    const externalSession = path.join(externalDir, 'target.jsonl');
+
+    try {
+      fs.writeFileSync(externalSession, '{"type":"user","message":{"content":"outside"}}\n');
+      fs.symlinkSync(externalSession, path.join(sessionDir, 'escape.jsonl'));
+
+      expect(() => resolveExactSessionFile(sessionDir, 'escape'))
+        .toThrow(/outside|session directory/i);
+    } finally {
+      fs.rmSync(sessionDir, { recursive: true, force: true });
+      fs.rmSync(externalDir, { recursive: true, force: true });
+    }
+  });
+
+  test('resolveExactSessionFile rejects exact session targets that are not regular files', () => {
+    const sessionDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-exact-session-'));
+
+    try {
+      fs.mkdirSync(path.join(sessionDir, 'directory-session.jsonl'));
+
+      expect(() => resolveExactSessionFile(sessionDir, 'directory-session'))
+        .toThrow(/regular file/i);
+    } finally {
+      fs.rmSync(sessionDir, { recursive: true, force: true });
+    }
   });
 
   test('validateSubagentParent rejects parent metadata for a different project', () => {

--- a/tests/mcp-security.test.js
+++ b/tests/mcp-security.test.js
@@ -1,0 +1,110 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  parseAllowedRoots,
+  validateProjectPath,
+  validateSessionDir,
+  validateSubagentParent,
+  defaultIncludeContext
+} = require('../src/utils/sidecar-boundaries');
+const { buildContext } = require('../src/sidecar/context-builder');
+const { saveApiKey } = require('../src/utils/api-key-store');
+
+describe('sidecar workspace boundaries', () => {
+  const repoRoot = fs.realpathSync(path.resolve(__dirname, '..'));
+
+  test('parseAllowedRoots rejects non-absolute roots', () => {
+    expect(() => parseAllowedRoots('relative/path')).toThrow(/absolute/i);
+  });
+
+  test('validateProjectPath rejects broad system roots by default', () => {
+    const options = { cwd: repoRoot, allowedRoots: [repoRoot] };
+
+    expect(() => validateProjectPath('/tmp', options)).toThrow(/not allowed|unsafe/i);
+    expect(() => validateProjectPath('/', options)).toThrow(/not allowed|unsafe/i);
+    expect(() => validateProjectPath(os.homedir(), options)).toThrow(/not allowed|unsafe/i);
+  });
+
+  test('validateProjectPath accepts and canonicalizes a descendant of the repo root', () => {
+    const expected = fs.realpathSync(path.join(repoRoot, 'src'));
+
+    expect(validateProjectPath(path.join(repoRoot, 'src'), {
+      cwd: repoRoot,
+      allowedRoots: [repoRoot]
+    })).toBe(expected);
+  });
+
+  test('validateProjectPath rejects a symlink inside an allowed root resolving outside that root', () => {
+    const allowedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-allowed-'));
+    const outsideRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-outside-'));
+    const escapeLink = path.join(allowedRoot, 'escape');
+
+    try {
+      fs.symlinkSync(outsideRoot, escapeLink);
+
+      expect(() => validateProjectPath(escapeLink, {
+        cwd: allowedRoot,
+        allowedRoots: [allowedRoot]
+      })).toThrow(/not allowed|outside/i);
+    } finally {
+      fs.rmSync(allowedRoot, { recursive: true, force: true });
+      fs.rmSync(outsideRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('defaultIncludeContext returns false', () => {
+    expect(defaultIncludeContext()).toBe(false);
+  });
+});
+
+describe('sidecar context boundaries', () => {
+  const repoRoot = fs.realpathSync(path.resolve(__dirname, '..'));
+
+  test('buildContext rejects cross-project context', () => {
+    expect(() => buildContext('/other/project', 'session-a', {
+      parentProject: repoRoot
+    })).toThrow(/project/i);
+  });
+
+  test('validateSessionDir rejects session directories outside the project root', () => {
+    expect(() => validateSessionDir(
+      path.join('/other/project', '.claude', 'sidecar_sessions', 'session-a'),
+      repoRoot
+    )).toThrow(/project|outside/i);
+  });
+
+  test('validateSubagentParent rejects parent metadata for a different project', () => {
+    expect(() => validateSubagentParent({
+      projectDir: '/other/project',
+      parentTaskId: 'task-a'
+    }, repoRoot)).toThrow(/project/i);
+  });
+});
+
+describe('sidecar secret file permissions', () => {
+  let tmpDir;
+  let originalEnv;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-secrets-'));
+    originalEnv = { ...process.env };
+    process.env.SIDECAR_ENV_DIR = path.join(tmpDir, 'config', 'sidecar');
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('saving an API key creates env dir mode 0700 and .env mode 0600', () => {
+    saveApiKey('openrouter', 'sk-or-test-secret');
+
+    const envDir = process.env.SIDECAR_ENV_DIR;
+    const envPath = path.join(envDir, '.env');
+
+    expect(fs.statSync(envDir).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(envPath).mode & 0o777).toBe(0o600);
+  });
+});

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -470,6 +470,41 @@ describe('MCP Server Handlers', () => {
       }
     });
 
+    test('skips symlinked session entries that resolve outside the sidecar sessions root', async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-list-symlink-'));
+      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-list-outside-'));
+      const sessionsBase = path.join(tmpDir, '.claude', 'sidecar_sessions');
+      const validDir = path.join(sessionsBase, 'inside1');
+      fs.mkdirSync(validDir, { recursive: true });
+      fs.writeFileSync(path.join(validDir, 'metadata.json'), JSON.stringify({
+        taskId: 'inside1',
+        status: 'complete',
+        model: 'gemini',
+        briefing: 'inside session',
+        createdAt: '2026-03-04T00:00:00.000Z',
+      }));
+      fs.writeFileSync(path.join(outsideDir, 'metadata.json'), JSON.stringify({
+        taskId: 'leak',
+        status: 'complete',
+        model: 'outside-model',
+        briefing: 'outside secret briefing',
+        createdAt: '2026-03-05T00:00:00.000Z',
+      }));
+      fs.symlinkSync(outsideDir, path.join(sessionsBase, 'leak'), 'dir');
+
+      try {
+        const result = await handlers.sidecar_list({}, tmpDir);
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed).toHaveLength(1);
+        expect(parsed[0].id).toBe('inside1');
+        expect(result.content[0].text).not.toContain('outside secret briefing');
+        expect(result.content[0].text).not.toContain('outside-model');
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        fs.rmSync(outsideDir, { recursive: true, force: true });
+      }
+    });
+
     test('filters sessions by status', async () => {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-test-'));
       const sessionsBase = path.join(tmpDir, '.claude', 'sidecar_sessions');
@@ -559,6 +594,51 @@ describe('MCP Server Handlers', () => {
         expect(parsed).toHaveProperty('latest');
       } finally {
         fs.rmSync(tmpDir, { recursive: true });
+      }
+    });
+
+    test('does not expose progress from symlinked files outside a valid session directory', async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-progress-symlink-'));
+      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-progress-outside-'));
+      const sessDir = path.join(tmpDir, '.claude', 'sidecar_sessions', 'progx');
+      fs.mkdirSync(sessDir, { recursive: true });
+      fs.writeFileSync(path.join(sessDir, 'metadata.json'), JSON.stringify({
+        taskId: 'progx',
+        status: 'running',
+        pid: process.pid,
+        model: 'gemini',
+        headless: true,
+        createdAt: new Date().toISOString(),
+      }));
+      fs.writeFileSync(
+        path.join(outsideDir, 'conversation.jsonl'),
+        JSON.stringify({ role: 'assistant', content: 'outside secret progress' }) + '\n'
+      );
+      fs.writeFileSync(
+        path.join(outsideDir, 'progress.json'),
+        JSON.stringify({
+          stage: 'receiving',
+          stageLabel: 'outside secret stage',
+          updatedAt: new Date().toISOString()
+        })
+      );
+      fs.symlinkSync(path.join(outsideDir, 'conversation.jsonl'), path.join(sessDir, 'conversation.jsonl'));
+      fs.symlinkSync(path.join(outsideDir, 'progress.json'), path.join(sessDir, 'progress.json'));
+
+      try {
+        const result = await handlers.sidecar_status({ taskId: 'progx' }, tmpDir);
+        expect(result.isError).toBeUndefined();
+        const text = result.content.map(c => c.text).join('\n');
+        const parsed = JSON.parse(result.content[0].text);
+        expect(parsed.status).toBe('running');
+        expect(parsed.latest).toBe('Starting up...');
+        expect(parsed.messages).toBe(0);
+        expect(parsed.stage).toBeUndefined();
+        expect(text).not.toContain('outside secret progress');
+        expect(text).not.toContain('outside secret stage');
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        fs.rmSync(outsideDir, { recursive: true, force: true });
       }
     });
 

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -112,6 +112,42 @@ describe('MCP spawn arg building', () => {
     });
   });
 
+  test('sidecar_start omits ambient secret env when spawning the sidecar CLI', async () => {
+    const originalEnv = { ...process.env };
+    let capturedOptions;
+
+    try {
+      process.env.AWS_SECRET_ACCESS_KEY = 'aws-secret';
+      process.env.OPENAI_API_KEY = 'openai-secret';
+      process.env.ANTHROPIC_API_KEY = 'anthropic-secret';
+      process.env.SIDECAR_ENV_DIR = path.join(os.tmpdir(), 'sidecar-env-dir');
+      process.env.SIDECAR_SHARED_SERVER = '0';
+      process.env.LOG_LEVEL = 'debug';
+
+      await jest.isolateModulesAsync(async () => {
+        jest.doMock('child_process', () => ({
+          spawn: jest.fn((cmd, args, options) => {
+            capturedOptions = options;
+            return { pid: 12345, unref: jest.fn(), stdout: { on: jest.fn() }, stderr: { on: jest.fn() } };
+          }),
+        }));
+        const { handlers: h } = require('../src/mcp-server');
+        await h.sidecar_start({ prompt: 'test task', noUi: true, model: 'google/gemini-test' }, repoRoot);
+      });
+
+      expect(capturedOptions.env).toBeDefined();
+      expect(capturedOptions.env.PATH).toBe(process.env.PATH);
+      expect(capturedOptions.env.SIDECAR_ENV_DIR).toBe(process.env.SIDECAR_ENV_DIR);
+      expect(capturedOptions.env.LOG_LEVEL).toBe('debug');
+      expect(capturedOptions.env.SIDECAR_DEBUG_PORT).toBe('9223');
+      expect(capturedOptions.env.AWS_SECRET_ACCESS_KEY).toBeUndefined();
+      expect(capturedOptions.env.OPENAI_API_KEY).toBeUndefined();
+      expect(capturedOptions.env.ANTHROPIC_API_KEY).toBeUndefined();
+    } finally {
+      process.env = originalEnv;
+    }
+  });
+
   test('sidecar_continue returns a NEW taskId, not the parent taskId', async () => {
     await jest.isolateModulesAsync(async () => {
       jest.doMock('child_process', () => ({
@@ -220,6 +256,82 @@ describe('MCP shared server exact context resolution', () => {
       jest.dontMock('../src/sidecar/session-utils');
       jest.resetModules();
       fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('sidecar_start rejects fake coworkProcess includeContext before launching shared run', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-shared-cowork-'));
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-shared-home-'));
+    const originalHome = process.env.HOME;
+    const runHeadlessMock = jest.fn(async () => ({ summary: 'done' }));
+    const sharedServerMock = {
+      enabled: true,
+      ensureServer: jest.fn(async () => ({
+        server: { url: 'http://127.0.0.1:43210', goPid: 1234 },
+        client: {}
+      })),
+      addSession: jest.fn(),
+      getSessionWatchdog: jest.fn(() => ({})),
+      removeSession: jest.fn(),
+      shutdown: jest.fn()
+    };
+
+    try {
+      process.env.HOME = tmpHome;
+
+      await jest.isolateModulesAsync(async () => {
+        jest.doMock('child_process', () => ({
+          spawn: jest.fn(() => ({
+            pid: 12345,
+            unref: jest.fn(),
+            stdout: { on: jest.fn() },
+            stderr: { on: jest.fn() }
+          }))
+        }));
+        jest.doMock('../src/utils/shared-server', () => ({
+          SharedServerManager: jest.fn(() => sharedServerMock)
+        }));
+        jest.doMock('../src/opencode-client', () => ({
+          createSession: jest.fn(async () => 'shared-opencode-session')
+        }));
+        jest.doMock('../src/prompt-builder', () => ({
+          buildPrompts: jest.fn(() => ({ system: 'sys', userMessage: 'user' }))
+        }));
+        jest.doMock('../src/headless', () => ({
+          runHeadless: runHeadlessMock
+        }));
+        jest.doMock('../src/sidecar/session-utils', () => ({
+          finalizeSession: jest.fn()
+        }));
+
+        const { handlers: h } = require('../src/mcp-server');
+        const result = await h.sidecar_start({
+          prompt: 'test task',
+          noUi: true,
+          model: 'google/gemini-test',
+          includeContext: true,
+          coworkProcess: 'fake-process'
+        }, tmpDir);
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toMatch(/Cowork session.*fake-process.*not found/i);
+        expect(runHeadlessMock).not.toHaveBeenCalled();
+      });
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      jest.dontMock('child_process');
+      jest.dontMock('../src/utils/shared-server');
+      jest.dontMock('../src/opencode-client');
+      jest.dontMock('../src/prompt-builder');
+      jest.dontMock('../src/headless');
+      jest.dontMock('../src/sidecar/session-utils');
+      jest.resetModules();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.rmSync(tmpHome, { recursive: true, force: true });
     }
   });
 });

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -184,6 +184,8 @@ describe('MCP Server Handlers', () => {
       'sidecar_start', 'sidecar_status', 'sidecar_read',
       'sidecar_list', 'sidecar_resume', 'sidecar_continue',
       'sidecar_setup', 'sidecar_guide', 'sidecar_abort',
+      'sidecar_subagent_start', 'sidecar_subagent_status',
+      'sidecar_subagent_read', 'sidecar_subagent_abort',
     ];
     for (const name of expectedTools) {
       expect(handlers).toHaveProperty(name);

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -10,6 +10,8 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
+const repoRoot = fs.realpathSync(path.resolve(__dirname, '..'));
+
 /**
  * Tests that verify the args passed to the spawned CLI process.
  * Uses jest.isolateModulesAsync + jest.doMock to mock child_process per-test.
@@ -26,7 +28,7 @@ describe('MCP spawn arg building', () => {
         }),
       }));
       const { handlers: h } = require('../src/mcp-server');
-      const result = await h.sidecar_start({ prompt: 'test task', noUi: true, model: 'google/gemini-test' }, '/tmp');
+      const result = await h.sidecar_start({ prompt: 'test task', noUi: true, model: 'google/gemini-test' }, repoRoot);
       const { taskId } = JSON.parse(result.content[0].text);
       const idx = capturedArgs.indexOf('--task-id');
       expect(idx).toBeGreaterThan(-1);
@@ -44,7 +46,7 @@ describe('MCP spawn arg building', () => {
         }),
       }));
       const { handlers: h } = require('../src/mcp-server');
-      await h.sidecar_start({ prompt: 'test task', noUi: true, model: 'google/gemini-test' }, '/tmp');
+      await h.sidecar_start({ prompt: 'test task', noUi: true, model: 'google/gemini-test' }, repoRoot);
       const idx = capturedArgs.indexOf('--client');
       expect(idx).toBeGreaterThan(-1);
       expect(capturedArgs[idx + 1]).toBe('cowork');
@@ -61,7 +63,7 @@ describe('MCP spawn arg building', () => {
         }),
       }));
       const { handlers: h } = require('../src/mcp-server');
-      await h.sidecar_start({ prompt: 'test task', noUi: true, model: 'google/gemini-test', parentSession: 'f58f2782-fc8c-41bc-afbc-e0c130b91aaf' }, '/tmp');
+      await h.sidecar_start({ prompt: 'test task', noUi: true, model: 'google/gemini-test', parentSession: 'f58f2782-fc8c-41bc-afbc-e0c130b91aaf' }, repoRoot);
       const idx = capturedArgs.indexOf('--session-id');
       expect(idx).toBeGreaterThan(-1);
       expect(capturedArgs[idx + 1]).toBe('f58f2782-fc8c-41bc-afbc-e0c130b91aaf');
@@ -78,7 +80,7 @@ describe('MCP spawn arg building', () => {
         }),
       }));
       const { handlers: h } = require('../src/mcp-server');
-      await h.sidecar_start({ prompt: 'test task', noUi: true, model: 'google/gemini-test', timeout: 30 }, '/tmp');
+      await h.sidecar_start({ prompt: 'test task', noUi: true, model: 'google/gemini-test', timeout: 30 }, repoRoot);
       const idx = capturedArgs.indexOf('--timeout');
       expect(idx).toBeGreaterThan(-1);
       expect(capturedArgs[idx + 1]).toBe('30');
@@ -96,7 +98,7 @@ describe('MCP spawn arg building', () => {
       const { handlers: h } = require('../src/mcp-server');
       const parentTaskId = 'parent123';
       const result = await h.sidecar_continue(
-        { taskId: parentTaskId, prompt: 'follow-up task', noUi: true }, '/tmp'
+        { taskId: parentTaskId, prompt: 'follow-up task', noUi: true }, repoRoot
       );
       const { taskId } = JSON.parse(result.content[0].text);
       expect(taskId).not.toBe(parentTaskId);
@@ -115,7 +117,7 @@ describe('MCP spawn arg building', () => {
       }));
       const { handlers: h } = require('../src/mcp-server');
       const result = await h.sidecar_continue(
-        { taskId: 'old-parent', prompt: 'new task', noUi: true }, '/tmp'
+        { taskId: 'old-parent', prompt: 'new task', noUi: true }, repoRoot
       );
       const { taskId: newTaskId } = JSON.parse(result.content[0].text);
       const idx = capturedArgs.indexOf('--task-id');
@@ -889,7 +891,7 @@ describe('MCP Server Handlers', () => {
           }),
         }));
         const { handlers: h } = require('../src/mcp-server');
-        const result = await h.sidecar_start({ prompt: 'analyze auth', noUi: false, model: 'google/gemini-test' }, '/tmp');
+        const result = await h.sidecar_start({ prompt: 'analyze auth', noUi: false, model: 'google/gemini-test' }, repoRoot);
         const parsed = JSON.parse(result.content[0].text);
         expect(parsed.mode).toBe('interactive');
         expect(parsed.message).toContain('Do NOT poll');
@@ -907,7 +909,7 @@ describe('MCP Server Handlers', () => {
           }),
         }));
         const { handlers: h } = require('../src/mcp-server');
-        const result = await h.sidecar_start({ prompt: 'implement feature', noUi: true, model: 'google/gemini-test' }, '/tmp');
+        const result = await h.sidecar_start({ prompt: 'implement feature', noUi: true, model: 'google/gemini-test' }, repoRoot);
         const parsed = JSON.parse(result.content[0].text);
         expect(parsed.mode).toBe('headless');
         expect(parsed.message).toContain('headless');
@@ -920,7 +922,7 @@ describe('MCP Server Handlers', () => {
           spawn: jest.fn(() => ({ pid: 12345, unref: jest.fn() })),
         }));
         const { handlers: h } = require('../src/mcp-server');
-        const result = await h.sidecar_start({ prompt: 'test task', noUi: true, model: 'google/gemini-test' }, '/tmp');
+        const result = await h.sidecar_start({ prompt: 'test task', noUi: true, model: 'google/gemini-test' }, repoRoot);
         expect(result.content).toHaveLength(2);
         expect(result.content[1].text).toContain('<system-reminder>');
         expect(result.content[1].text).toContain('sleep 25');
@@ -933,7 +935,7 @@ describe('MCP Server Handlers', () => {
           spawn: jest.fn(() => ({ pid: 12345, unref: jest.fn() })),
         }));
         const { handlers: h } = require('../src/mcp-server');
-        const result = await h.sidecar_start({ prompt: 'analyze auth', noUi: false, model: 'google/gemini-test' }, '/tmp');
+        const result = await h.sidecar_start({ prompt: 'analyze auth', noUi: false, model: 'google/gemini-test' }, repoRoot);
         expect(result.content).toHaveLength(1);
         expect(result.content[0].text).not.toContain('<system-reminder>');
       });
@@ -1075,10 +1077,13 @@ describe('sidecar_start context and summary args', () => {
         ...jest.requireActual('fs'),
         mkdirSync: jest.fn(),
         writeFileSync: jest.fn(),
-        existsSync: jest.fn(() => false)
+        existsSync: jest.fn((target) => {
+          const resolved = path.resolve(target);
+          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
+        })
       }));
       const { handlers } = require('../src/mcp-server');
-      await handlers.sidecar_start({ prompt: 'test', model: 'openrouter/test/model', contextTurns: 25 }, '/tmp/proj');
+      await handlers.sidecar_start({ prompt: 'test', model: 'openrouter/test/model', contextTurns: 25 }, repoRoot);
     });
     expect(capturedArgs).toContain('--context-turns');
     expect(capturedArgs).toContain('25');
@@ -1097,10 +1102,13 @@ describe('sidecar_start context and summary args', () => {
         ...jest.requireActual('fs'),
         mkdirSync: jest.fn(),
         writeFileSync: jest.fn(),
-        existsSync: jest.fn(() => false)
+        existsSync: jest.fn((target) => {
+          const resolved = path.resolve(target);
+          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
+        })
       }));
       const { handlers } = require('../src/mcp-server');
-      await handlers.sidecar_start({ prompt: 'test', model: 'openrouter/test/model', contextSince: '2h' }, '/tmp/proj');
+      await handlers.sidecar_start({ prompt: 'test', model: 'openrouter/test/model', contextSince: '2h' }, repoRoot);
     });
     expect(capturedArgs).toContain('--context-since');
     expect(capturedArgs).toContain('2h');
@@ -1119,10 +1127,13 @@ describe('sidecar_start context and summary args', () => {
         ...jest.requireActual('fs'),
         mkdirSync: jest.fn(),
         writeFileSync: jest.fn(),
-        existsSync: jest.fn(() => false)
+        existsSync: jest.fn((target) => {
+          const resolved = path.resolve(target);
+          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
+        })
       }));
       const { handlers } = require('../src/mcp-server');
-      await handlers.sidecar_start({ prompt: 'test', model: 'openrouter/test/model', contextMaxTokens: 40000 }, '/tmp/proj');
+      await handlers.sidecar_start({ prompt: 'test', model: 'openrouter/test/model', contextMaxTokens: 40000 }, repoRoot);
     });
     expect(capturedArgs).toContain('--context-max-tokens');
     expect(capturedArgs).toContain('40000');
@@ -1141,10 +1152,13 @@ describe('sidecar_start context and summary args', () => {
         ...jest.requireActual('fs'),
         mkdirSync: jest.fn(),
         writeFileSync: jest.fn(),
-        existsSync: jest.fn(() => false)
+        existsSync: jest.fn((target) => {
+          const resolved = path.resolve(target);
+          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
+        })
       }));
       const { handlers } = require('../src/mcp-server');
-      await handlers.sidecar_start({ prompt: 'test', model: 'openrouter/test/model', summaryLength: 'verbose' }, '/tmp/proj');
+      await handlers.sidecar_start({ prompt: 'test', model: 'openrouter/test/model', summaryLength: 'verbose' }, repoRoot);
     });
     expect(capturedArgs).toContain('--summary-length');
     expect(capturedArgs).toContain('verbose');
@@ -1163,10 +1177,13 @@ describe('sidecar_start context and summary args', () => {
         ...jest.requireActual('fs'),
         mkdirSync: jest.fn(),
         writeFileSync: jest.fn(),
-        existsSync: jest.fn(() => false)
+        existsSync: jest.fn((target) => {
+          const resolved = path.resolve(target);
+          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
+        })
       }));
       const { handlers } = require('../src/mcp-server');
-      await handlers.sidecar_start({ prompt: 'self-contained task', model: 'openrouter/test/model', includeContext: false }, '/tmp/proj');
+      await handlers.sidecar_start({ prompt: 'self-contained task', model: 'openrouter/test/model', includeContext: false }, repoRoot);
     });
     expect(capturedArgs).toContain('--no-context');
   });
@@ -1184,15 +1201,23 @@ describe('sidecar_start context and summary args', () => {
         ...jest.requireActual('fs'),
         mkdirSync: jest.fn(),
         writeFileSync: jest.fn(),
-        existsSync: jest.fn(() => false)
+        existsSync: jest.fn((target) => {
+          const resolved = path.resolve(target);
+          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
+        })
       }));
       const { handlers } = require('../src/mcp-server');
-      await handlers.sidecar_start({ prompt: 'needs context', model: 'openrouter/test/model', includeContext: true }, '/tmp/proj');
+      await handlers.sidecar_start({
+        prompt: 'needs context',
+        model: 'openrouter/test/model',
+        includeContext: true,
+        parentSession: 'session-a'
+      }, repoRoot);
     });
     expect(capturedArgs).not.toContain('--no-context');
   });
 
-  it('does NOT pass --no-context when includeContext is omitted', async () => {
+  it('passes --no-context when includeContext is omitted', async () => {
     let capturedArgs = [];
     await jest.isolateModulesAsync(async () => {
       jest.doMock('child_process', () => ({
@@ -1205,12 +1230,15 @@ describe('sidecar_start context and summary args', () => {
         ...jest.requireActual('fs'),
         mkdirSync: jest.fn(),
         writeFileSync: jest.fn(),
-        existsSync: jest.fn(() => false)
+        existsSync: jest.fn((target) => {
+          const resolved = path.resolve(target);
+          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
+        })
       }));
       const { handlers } = require('../src/mcp-server');
-      await handlers.sidecar_start({ prompt: 'default behavior', model: 'openrouter/test/model' }, '/tmp/proj');
+      await handlers.sidecar_start({ prompt: 'default behavior', model: 'openrouter/test/model' }, repoRoot);
     });
-    expect(capturedArgs).not.toContain('--no-context');
+    expect(capturedArgs).toContain('--no-context');
   });
 });
 
@@ -1228,10 +1256,13 @@ describe('sidecar_continue context args', () => {
         ...jest.requireActual('fs'),
         mkdirSync: jest.fn(),
         writeFileSync: jest.fn(),
-        existsSync: jest.fn(() => false)
+        existsSync: jest.fn((target) => {
+          const resolved = path.resolve(target);
+          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
+        })
       }));
       const { handlers } = require('../src/mcp-server');
-      await handlers.sidecar_continue({ taskId: 'abc123', prompt: 'continue task', contextTurns: 10 }, '/tmp/proj');
+      await handlers.sidecar_continue({ taskId: 'abc123', prompt: 'continue task', contextTurns: 10 }, repoRoot);
     });
     expect(capturedArgs).toContain('--context-turns');
     expect(capturedArgs).toContain('10');
@@ -1250,10 +1281,13 @@ describe('sidecar_continue context args', () => {
         ...jest.requireActual('fs'),
         mkdirSync: jest.fn(),
         writeFileSync: jest.fn(),
-        existsSync: jest.fn(() => false)
+        existsSync: jest.fn((target) => {
+          const resolved = path.resolve(target);
+          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
+        })
       }));
       const { handlers } = require('../src/mcp-server');
-      await handlers.sidecar_continue({ taskId: 'abc123', prompt: 'continue task', contextMaxTokens: 20000 }, '/tmp/proj');
+      await handlers.sidecar_continue({ taskId: 'abc123', prompt: 'continue task', contextMaxTokens: 20000 }, repoRoot);
     });
     expect(capturedArgs).toContain('--context-max-tokens');
     expect(capturedArgs).toContain('20000');

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -12,6 +12,34 @@ const os = require('os');
 
 const repoRoot = fs.realpathSync(path.resolve(__dirname, '..'));
 
+async function captureMcpSpawnArgs(runHandler) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-spawn-args-'));
+  const originalSharedServer = process.env.SIDECAR_SHARED_SERVER;
+  let capturedArgs = [];
+
+  try {
+    process.env.SIDECAR_SHARED_SERVER = '0';
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('child_process', () => ({
+        spawn: (_cmd, args, _opts) => {
+          capturedArgs = args;
+          return { pid: 1234, unref: jest.fn(), stdout: { on: jest.fn() }, stderr: { on: jest.fn() } };
+        }
+      }));
+      const { handlers } = require('../src/mcp-server');
+      await runHandler(handlers, tmpDir);
+    });
+    return capturedArgs;
+  } finally {
+    if (originalSharedServer === undefined) {
+      delete process.env.SIDECAR_SHARED_SERVER;
+    } else {
+      process.env.SIDECAR_SHARED_SERVER = originalSharedServer;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
 /**
  * Tests that verify the args passed to the spawned CLI process.
  * Uses jest.isolateModulesAsync + jest.doMock to mock child_process per-test.
@@ -1390,178 +1418,59 @@ describe('MCP Server Handlers', () => {
 
 describe('sidecar_start context and summary args', () => {
   it('passes --context-turns to CLI', async () => {
-    let capturedArgs = [];
-    await jest.isolateModulesAsync(async () => {
-      jest.doMock('child_process', () => ({
-        spawn: (_cmd, args, _opts) => {
-          capturedArgs = args;
-          return { pid: 1234, unref: jest.fn(), stdout: { on: jest.fn() }, stderr: { on: jest.fn() } };
-        }
-      }));
-      jest.doMock('fs', () => ({
-        ...jest.requireActual('fs'),
-        mkdirSync: jest.fn(),
-        writeFileSync: jest.fn(),
-        existsSync: jest.fn((target) => {
-          const resolved = path.resolve(target);
-          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
-        })
-      }));
-      const { handlers } = require('../src/mcp-server');
-      await handlers.sidecar_start({ prompt: 'test', model: 'openrouter/test/model', contextTurns: 25 }, repoRoot);
+    const capturedArgs = await captureMcpSpawnArgs(async (handlers, tmpDir) => {
+      await handlers.sidecar_start({ prompt: 'test', model: 'openrouter/test/model', contextTurns: 25 }, tmpDir);
     });
     expect(capturedArgs).toContain('--context-turns');
     expect(capturedArgs).toContain('25');
   });
 
   it('passes --context-since to CLI', async () => {
-    let capturedArgs = [];
-    await jest.isolateModulesAsync(async () => {
-      jest.doMock('child_process', () => ({
-        spawn: (_cmd, args, _opts) => {
-          capturedArgs = args;
-          return { pid: 1234, unref: jest.fn(), stdout: { on: jest.fn() }, stderr: { on: jest.fn() } };
-        }
-      }));
-      jest.doMock('fs', () => ({
-        ...jest.requireActual('fs'),
-        mkdirSync: jest.fn(),
-        writeFileSync: jest.fn(),
-        existsSync: jest.fn((target) => {
-          const resolved = path.resolve(target);
-          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
-        })
-      }));
-      const { handlers } = require('../src/mcp-server');
-      await handlers.sidecar_start({ prompt: 'test', model: 'openrouter/test/model', contextSince: '2h' }, repoRoot);
+    const capturedArgs = await captureMcpSpawnArgs(async (handlers, tmpDir) => {
+      await handlers.sidecar_start({ prompt: 'test', model: 'openrouter/test/model', contextSince: '2h' }, tmpDir);
     });
     expect(capturedArgs).toContain('--context-since');
     expect(capturedArgs).toContain('2h');
   });
 
   it('passes --context-max-tokens to CLI', async () => {
-    let capturedArgs = [];
-    await jest.isolateModulesAsync(async () => {
-      jest.doMock('child_process', () => ({
-        spawn: (_cmd, args, _opts) => {
-          capturedArgs = args;
-          return { pid: 1234, unref: jest.fn(), stdout: { on: jest.fn() }, stderr: { on: jest.fn() } };
-        }
-      }));
-      jest.doMock('fs', () => ({
-        ...jest.requireActual('fs'),
-        mkdirSync: jest.fn(),
-        writeFileSync: jest.fn(),
-        existsSync: jest.fn((target) => {
-          const resolved = path.resolve(target);
-          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
-        })
-      }));
-      const { handlers } = require('../src/mcp-server');
-      await handlers.sidecar_start({ prompt: 'test', model: 'openrouter/test/model', contextMaxTokens: 40000 }, repoRoot);
+    const capturedArgs = await captureMcpSpawnArgs(async (handlers, tmpDir) => {
+      await handlers.sidecar_start({ prompt: 'test', model: 'openrouter/test/model', contextMaxTokens: 40000 }, tmpDir);
     });
     expect(capturedArgs).toContain('--context-max-tokens');
     expect(capturedArgs).toContain('40000');
   });
 
   it('passes --summary-length to CLI', async () => {
-    let capturedArgs = [];
-    await jest.isolateModulesAsync(async () => {
-      jest.doMock('child_process', () => ({
-        spawn: (_cmd, args, _opts) => {
-          capturedArgs = args;
-          return { pid: 1234, unref: jest.fn(), stdout: { on: jest.fn() }, stderr: { on: jest.fn() } };
-        }
-      }));
-      jest.doMock('fs', () => ({
-        ...jest.requireActual('fs'),
-        mkdirSync: jest.fn(),
-        writeFileSync: jest.fn(),
-        existsSync: jest.fn((target) => {
-          const resolved = path.resolve(target);
-          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
-        })
-      }));
-      const { handlers } = require('../src/mcp-server');
-      await handlers.sidecar_start({ prompt: 'test', model: 'openrouter/test/model', summaryLength: 'verbose' }, repoRoot);
+    const capturedArgs = await captureMcpSpawnArgs(async (handlers, tmpDir) => {
+      await handlers.sidecar_start({ prompt: 'test', model: 'openrouter/test/model', summaryLength: 'verbose' }, tmpDir);
     });
     expect(capturedArgs).toContain('--summary-length');
     expect(capturedArgs).toContain('verbose');
   });
 
   it('passes --no-context to CLI when includeContext is false', async () => {
-    let capturedArgs = [];
-    await jest.isolateModulesAsync(async () => {
-      jest.doMock('child_process', () => ({
-        spawn: (_cmd, args, _opts) => {
-          capturedArgs = args;
-          return { pid: 1234, unref: jest.fn(), stdout: { on: jest.fn() }, stderr: { on: jest.fn() } };
-        }
-      }));
-      jest.doMock('fs', () => ({
-        ...jest.requireActual('fs'),
-        mkdirSync: jest.fn(),
-        writeFileSync: jest.fn(),
-        existsSync: jest.fn((target) => {
-          const resolved = path.resolve(target);
-          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
-        })
-      }));
-      const { handlers } = require('../src/mcp-server');
-      await handlers.sidecar_start({ prompt: 'self-contained task', model: 'openrouter/test/model', includeContext: false }, repoRoot);
+    const capturedArgs = await captureMcpSpawnArgs(async (handlers, tmpDir) => {
+      await handlers.sidecar_start({ prompt: 'self-contained task', model: 'openrouter/test/model', includeContext: false }, tmpDir);
     });
     expect(capturedArgs).toContain('--no-context');
   });
 
   it('does NOT pass --no-context when includeContext is true', async () => {
-    let capturedArgs = [];
-    await jest.isolateModulesAsync(async () => {
-      jest.doMock('child_process', () => ({
-        spawn: (_cmd, args, _opts) => {
-          capturedArgs = args;
-          return { pid: 1234, unref: jest.fn(), stdout: { on: jest.fn() }, stderr: { on: jest.fn() } };
-        }
-      }));
-      jest.doMock('fs', () => ({
-        ...jest.requireActual('fs'),
-        mkdirSync: jest.fn(),
-        writeFileSync: jest.fn(),
-        existsSync: jest.fn((target) => {
-          const resolved = path.resolve(target);
-          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
-        })
-      }));
-      const { handlers } = require('../src/mcp-server');
+    const capturedArgs = await captureMcpSpawnArgs(async (handlers, tmpDir) => {
       await handlers.sidecar_start({
         prompt: 'needs context',
         model: 'openrouter/test/model',
         includeContext: true,
         parentSession: 'session-a'
-      }, repoRoot);
+      }, tmpDir);
     });
     expect(capturedArgs).not.toContain('--no-context');
   });
 
   it('passes --no-context when includeContext is omitted', async () => {
-    let capturedArgs = [];
-    await jest.isolateModulesAsync(async () => {
-      jest.doMock('child_process', () => ({
-        spawn: (_cmd, args, _opts) => {
-          capturedArgs = args;
-          return { pid: 1234, unref: jest.fn(), stdout: { on: jest.fn() }, stderr: { on: jest.fn() } };
-        }
-      }));
-      jest.doMock('fs', () => ({
-        ...jest.requireActual('fs'),
-        mkdirSync: jest.fn(),
-        writeFileSync: jest.fn(),
-        existsSync: jest.fn((target) => {
-          const resolved = path.resolve(target);
-          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
-        })
-      }));
-      const { handlers } = require('../src/mcp-server');
-      await handlers.sidecar_start({ prompt: 'default behavior', model: 'openrouter/test/model' }, repoRoot);
+    const capturedArgs = await captureMcpSpawnArgs(async (handlers, tmpDir) => {
+      await handlers.sidecar_start({ prompt: 'default behavior', model: 'openrouter/test/model' }, tmpDir);
     });
     expect(capturedArgs).toContain('--no-context');
   });
@@ -1569,50 +1478,16 @@ describe('sidecar_start context and summary args', () => {
 
 describe('sidecar_continue context args', () => {
   it('passes --context-turns to CLI', async () => {
-    let capturedArgs = [];
-    await jest.isolateModulesAsync(async () => {
-      jest.doMock('child_process', () => ({
-        spawn: (_cmd, args, _opts) => {
-          capturedArgs = args;
-          return { pid: 1234, unref: jest.fn(), stdout: { on: jest.fn() }, stderr: { on: jest.fn() } };
-        }
-      }));
-      jest.doMock('fs', () => ({
-        ...jest.requireActual('fs'),
-        mkdirSync: jest.fn(),
-        writeFileSync: jest.fn(),
-        existsSync: jest.fn((target) => {
-          const resolved = path.resolve(target);
-          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
-        })
-      }));
-      const { handlers } = require('../src/mcp-server');
-      await handlers.sidecar_continue({ taskId: 'abc123', prompt: 'continue task', contextTurns: 10 }, repoRoot);
+    const capturedArgs = await captureMcpSpawnArgs(async (handlers, tmpDir) => {
+      await handlers.sidecar_continue({ taskId: 'abc123', prompt: 'continue task', contextTurns: 10 }, tmpDir);
     });
     expect(capturedArgs).toContain('--context-turns');
     expect(capturedArgs).toContain('10');
   });
 
   it('passes --context-max-tokens to CLI', async () => {
-    let capturedArgs = [];
-    await jest.isolateModulesAsync(async () => {
-      jest.doMock('child_process', () => ({
-        spawn: (_cmd, args, _opts) => {
-          capturedArgs = args;
-          return { pid: 1234, unref: jest.fn(), stdout: { on: jest.fn() }, stderr: { on: jest.fn() } };
-        }
-      }));
-      jest.doMock('fs', () => ({
-        ...jest.requireActual('fs'),
-        mkdirSync: jest.fn(),
-        writeFileSync: jest.fn(),
-        existsSync: jest.fn((target) => {
-          const resolved = path.resolve(target);
-          return resolved === repoRoot || resolved.startsWith(repoRoot + path.sep);
-        })
-      }));
-      const { handlers } = require('../src/mcp-server');
-      await handlers.sidecar_continue({ taskId: 'abc123', prompt: 'continue task', contextMaxTokens: 20000 }, repoRoot);
+    const capturedArgs = await captureMcpSpawnArgs(async (handlers, tmpDir) => {
+      await handlers.sidecar_continue({ taskId: 'abc123', prompt: 'continue task', contextMaxTokens: 20000 }, tmpDir);
     });
     expect(capturedArgs).toContain('--context-max-tokens');
     expect(capturedArgs).toContain('20000');

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -1235,6 +1235,42 @@ describe('MCP Server Handlers', () => {
     test('handler is an async function', () => {
       expect(typeof handlers.sidecar_resume).toBe('function');
     });
+
+    test('does not truncate an outside debug.log target when debug.log is a symlink', async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-resume-debug-'));
+      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-resume-outside-'));
+      const sessionDir = path.join(tmpDir, '.claude', 'sidecar_sessions', 'resume-debug');
+      const outsideDebug = path.join(outsideDir, 'debug.log');
+
+      try {
+        fs.mkdirSync(sessionDir, { recursive: true });
+        fs.writeFileSync(path.join(sessionDir, 'metadata.json'), JSON.stringify({
+          taskId: 'resume-debug',
+          status: 'running',
+          model: 'gemini',
+          project: tmpDir,
+          projectDir: tmpDir,
+          createdAt: new Date().toISOString()
+        }));
+        fs.writeFileSync(outsideDebug, 'outside debug content');
+        fs.symlinkSync(outsideDebug, path.join(sessionDir, 'debug.log'));
+
+        await jest.isolateModulesAsync(async () => {
+          jest.doMock('child_process', () => ({
+            spawn: jest.fn(() => {
+              return { pid: 12345, unref: jest.fn() };
+            }),
+          }));
+          const { handlers: h } = require('../src/mcp-server');
+          await h.sidecar_resume({ taskId: 'resume-debug', noUi: true }, tmpDir);
+        });
+
+        expect(fs.readFileSync(outsideDebug, 'utf-8')).toBe('outside debug content');
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        fs.rmSync(outsideDir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('sidecar_continue', () => {

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -152,6 +152,78 @@ describe('MCP spawn arg building', () => {
   });
 });
 
+describe('MCP shared server exact context resolution', () => {
+  test('sidecar_start rejects missing exact parentSession instead of allowing fallback', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-shared-exact-'));
+    const sharedServerMock = {
+      enabled: true,
+      ensureServer: jest.fn(async () => ({
+        server: { url: 'http://127.0.0.1:43210', goPid: 1234 },
+        client: {}
+      })),
+      addSession: jest.fn(),
+      getSessionWatchdog: jest.fn(() => ({})),
+      removeSession: jest.fn(),
+      shutdown: jest.fn()
+    };
+    const buildContextMock = jest.fn((_project, _session, options) => {
+      if (options.exactSession === true) {
+        throw new Error('Exact session missing-session not found');
+      }
+      return 'fallback context';
+    });
+
+    try {
+      await jest.isolateModulesAsync(async () => {
+        jest.doMock('../src/utils/shared-server', () => ({
+          SharedServerManager: jest.fn(() => sharedServerMock)
+        }));
+        jest.doMock('../src/opencode-client', () => ({
+          createSession: jest.fn(async () => 'shared-opencode-session')
+        }));
+        jest.doMock('../src/sidecar/context-builder', () => ({
+          buildContext: buildContextMock
+        }));
+        jest.doMock('../src/prompt-builder', () => ({
+          buildPrompts: jest.fn(() => ({ system: 'sys', userMessage: 'user' }))
+        }));
+        jest.doMock('../src/headless', () => ({
+          runHeadless: jest.fn(async () => ({ summary: 'done' }))
+        }));
+        jest.doMock('../src/sidecar/session-utils', () => ({
+          finalizeSession: jest.fn()
+        }));
+
+        const { handlers: h } = require('../src/mcp-server');
+        const result = await h.sidecar_start({
+          prompt: 'test task',
+          noUi: true,
+          model: 'google/gemini-test',
+          includeContext: true,
+          parentSession: 'missing-session'
+        }, tmpDir);
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain('Exact session missing-session not found');
+        expect(buildContextMock).toHaveBeenCalledWith(
+          fs.realpathSync(tmpDir),
+          'missing-session',
+          expect.objectContaining({ exactSession: true })
+        );
+      });
+    } finally {
+      jest.dontMock('../src/utils/shared-server');
+      jest.dontMock('../src/opencode-client');
+      jest.dontMock('../src/sidecar/context-builder');
+      jest.dontMock('../src/prompt-builder');
+      jest.dontMock('../src/headless');
+      jest.dontMock('../src/sidecar/session-utils');
+      jest.resetModules();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('safeSessionDir (shared validator)', () => {
   const { safeSessionDir, validateTaskId } = require('../src/utils/validators');
 

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -70,6 +70,31 @@ describe('MCP spawn arg building', () => {
     });
   });
 
+  test('sidecar_start passes --include-context when includeContext is true', async () => {
+    let capturedArgs;
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('child_process', () => ({
+        spawn: jest.fn((cmd, args) => {
+          capturedArgs = args;
+          return { pid: 12345, unref: jest.fn(), stdout: { on: jest.fn() }, stderr: { on: jest.fn() } };
+        }),
+      }));
+      const { handlers: h } = require('../src/mcp-server');
+      await h.sidecar_start({
+        prompt: 'test task',
+        noUi: true,
+        model: 'google/gemini-test',
+        includeContext: true,
+        parentSession: 'f58f2782-fc8c-41bc-afbc-e0c130b91aaf'
+      }, repoRoot);
+
+      expect(capturedArgs).toContain('--include-context');
+      expect(capturedArgs).not.toContain('--no-context');
+      const idx = capturedArgs.indexOf('--session-id');
+      expect(capturedArgs[idx + 1]).toBe('f58f2782-fc8c-41bc-afbc-e0c130b91aaf');
+    });
+  });
+
   test('sidecar_start passes --timeout when provided', async () => {
     let capturedArgs;
     await jest.isolateModulesAsync(async () => {

--- a/tests/mcp-tools.test.js
+++ b/tests/mcp-tools.test.js
@@ -154,10 +154,10 @@ describe('MCP Tool Definitions', () => {
       expect(startTool.inputSchema).toHaveProperty('includeContext');
     });
 
-    test('includeContext defaults to true', () => {
+    test('includeContext defaults to false', () => {
       const schema = startTool.inputSchema.includeContext;
       expect(schema._def.typeName).toBe('ZodDefault');
-      expect(schema._def.defaultValue()).toBe(true);
+      expect(schema._def.defaultValue()).toBe(false);
     });
 
     test('has parentSession in input schema', () => {
@@ -378,7 +378,7 @@ describe('MCP Tool Definitions', () => {
     test('contains context control guidance', () => {
       const guide = getGuideText();
       expect(guide).toContain('## Context Control (includeContext)');
-      expect(guide).toContain('includeContext: false');
+      expect(guide).toContain('includeContext: true');
       expect(guide).toContain('Safe to Skip Context');
       expect(guide).toContain('Self-Contained Briefing Template');
     });

--- a/tests/mcp-tools.test.js
+++ b/tests/mcp-tools.test.js
@@ -35,10 +35,14 @@ describe('MCP Tool Definitions', () => {
     expect(names).toContain('sidecar_setup');
     expect(names).toContain('sidecar_guide');
     expect(names).toContain('sidecar_abort');
+    expect(names).toContain('sidecar_subagent_start');
+    expect(names).toContain('sidecar_subagent_status');
+    expect(names).toContain('sidecar_subagent_read');
+    expect(names).toContain('sidecar_subagent_abort');
   });
 
-  test('has exactly 9 tools', () => {
-    expect(TOOLS).toHaveLength(9);
+  test('has exactly 13 tools', () => {
+    expect(TOOLS).toHaveLength(13);
   });
 
   test('tool names are unique', () => {
@@ -273,6 +277,48 @@ describe('MCP Tool Definitions', () => {
     });
   });
 
+  describe('sidecar_subagent_start', () => {
+    test('has the expected schema fields', () => {
+      const tool = TOOLS.find(t => t.name === 'sidecar_subagent_start');
+      expect(tool.inputSchema).toHaveProperty('parentTaskId');
+      expect(tool.inputSchema).toHaveProperty('prompt');
+      expect(tool.inputSchema).toHaveProperty('agentType');
+      expect(tool.inputSchema).toHaveProperty('model');
+    });
+
+    test('supports the four codex-safe subagent types', () => {
+      const tool = TOOLS.find(t => t.name === 'sidecar_subagent_start');
+      expect(tool.inputSchema.agentType._def.values).toEqual(
+        expect.arrayContaining(['plan', 'explore', 'build', 'general'])
+      );
+    });
+  });
+
+  describe('sidecar_subagent_status', () => {
+    test('has parentTaskId and subagentId in input schema', () => {
+      const tool = TOOLS.find(t => t.name === 'sidecar_subagent_status');
+      expect(tool.inputSchema).toHaveProperty('parentTaskId');
+      expect(tool.inputSchema).toHaveProperty('subagentId');
+    });
+  });
+
+  describe('sidecar_subagent_read', () => {
+    test('has parentTaskId, subagentId, and mode in input schema', () => {
+      const tool = TOOLS.find(t => t.name === 'sidecar_subagent_read');
+      expect(tool.inputSchema).toHaveProperty('parentTaskId');
+      expect(tool.inputSchema).toHaveProperty('subagentId');
+      expect(tool.inputSchema).toHaveProperty('mode');
+    });
+  });
+
+  describe('sidecar_subagent_abort', () => {
+    test('has parentTaskId and subagentId in input schema', () => {
+      const tool = TOOLS.find(t => t.name === 'sidecar_subagent_abort');
+      expect(tool.inputSchema).toHaveProperty('parentTaskId');
+      expect(tool.inputSchema).toHaveProperty('subagentId');
+    });
+  });
+
   describe('polling guidance in descriptions', () => {
     test('sidecar_start description mentions interactive and headless modes', () => {
       const tool = TOOLS.find(t => t.name === 'sidecar_start');
@@ -300,6 +346,12 @@ describe('MCP Tool Definitions', () => {
       expect(guide).toContain('sidecar_start');
       expect(guide).toContain('sidecar_status');
       expect(guide).toContain('sidecar_read');
+    });
+
+    test('mentions experimental codex subagents', () => {
+      const guide = getGuideText();
+      expect(guide).toContain('sidecar_subagent_*');
+      expect(guide).toContain('Codex-backed subagents');
     });
 
     test('contains agent selection guidance', () => {
@@ -383,6 +435,8 @@ describe('MCP Tool Definitions', () => {
     const toolsWithProject = [
       'sidecar_start', 'sidecar_status', 'sidecar_read',
       'sidecar_list', 'sidecar_resume', 'sidecar_continue', 'sidecar_abort',
+      'sidecar_subagent_start', 'sidecar_subagent_status',
+      'sidecar_subagent_read', 'sidecar_subagent_abort',
     ];
 
     for (const name of toolsWithProject) {

--- a/tests/opencode-client.test.js
+++ b/tests/opencode-client.test.js
@@ -27,7 +27,8 @@ const {
   sendPrompt,
   createSession,
   getMessages,
-  checkHealth
+  checkHealth,
+  buildServerOptions
 } = require('../src/opencode-client');
 
 describe('OpenCode Client Wrapper', () => {
@@ -555,6 +556,72 @@ describe('OpenCode Client Wrapper', () => {
     it('should be the same function as sendPrompt', () => {
       const { sendPrompt, sendPromptAsync } = require('../src/opencode-client');
       expect(sendPromptAsync).toBe(sendPrompt);
+    });
+  });
+
+  describe('buildServerOptions MCP environment safety', () => {
+    let originalEnv;
+
+    beforeEach(() => {
+      originalEnv = { ...process.env };
+      process.env.OPENAI_API_KEY = 'openai-secret';
+      process.env.ANTHROPIC_API_KEY = 'anthropic-secret';
+      process.env.OPENROUTER_API_KEY = 'openrouter-secret';
+      process.env.AWS_SECRET_ACCESS_KEY = 'aws-secret';
+      process.env.SERVICE_TOKEN = 'service-token';
+      process.env.LOG_LEVEL = 'debug';
+      process.env.SIDECAR_ENV_DIR = '/tmp/sidecar-env-dir';
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('masks ambient secret env for local MCP commands', () => {
+      const opts = buildServerOptions({
+        mcp: {
+          'local-server': {
+            command: 'node',
+            args: ['server.js']
+          }
+        }
+      });
+
+      const local = opts.config.mcp['local-server'];
+      expect(local).toMatchObject({
+        type: 'local',
+        enabled: true,
+        command: ['node', 'server.js']
+      });
+      expect(local.environment).toBeDefined();
+      expect(local.environment.OPENAI_API_KEY).toBe('');
+      expect(local.environment.ANTHROPIC_API_KEY).toBe('');
+      expect(local.environment.OPENROUTER_API_KEY).toBe('');
+      expect(local.environment.AWS_SECRET_ACCESS_KEY).toBe('');
+      expect(local.environment.SERVICE_TOKEN).toBe('');
+    });
+
+    it('preserves nonsecret MCP environment while masking ambient secrets', () => {
+      const opts = buildServerOptions({
+        mcp: {
+          'local-server': {
+            type: 'local',
+            command: ['node', 'server.js'],
+            environment: {
+              MCP_MODE: 'stdio',
+              LOCAL_FLAG: 'enabled'
+            }
+          }
+        }
+      });
+
+      const localEnv = opts.config.mcp['local-server'].environment;
+      expect(localEnv.MCP_MODE).toBe('stdio');
+      expect(localEnv.LOCAL_FLAG).toBe('enabled');
+      expect(localEnv.LOG_LEVEL).toBe('debug');
+      expect(localEnv.SIDECAR_ENV_DIR).toBe('/tmp/sidecar-env-dir');
+      expect(localEnv.OPENAI_API_KEY).toBe('');
+      expect(localEnv.AWS_SECRET_ACCESS_KEY).toBe('');
     });
   });
 

--- a/tests/session-manager.test.js
+++ b/tests/session-manager.test.js
@@ -249,6 +249,29 @@ describe('Session Manager', () => {
         updateSession(projectDir, 'nonexistent', { status: 'complete' });
       }).toThrow(/not found/);
     });
+
+    it('rejects a metadata symlink before updating an outside target', () => {
+      const metaPath = path.join(projectDir, '.claude', 'sidecar_sessions', 'abc123', 'metadata.json');
+      const outsideMetadata = path.join(tempDir, 'outside-metadata.json');
+      fs.writeFileSync(outsideMetadata, JSON.stringify({
+        taskId: 'abc123',
+        model: 'outside/model',
+        project: projectDir,
+        status: 'running',
+        filesRead: [],
+        filesWritten: [],
+        conflicts: []
+      }));
+      fs.unlinkSync(metaPath);
+      fs.symlinkSync(outsideMetadata, metaPath);
+
+      expect(() => {
+        updateSession(projectDir, 'abc123', { status: SESSION_STATUS.COMPLETE });
+      }).toThrow(/symbolic link|session directory|outside/i);
+
+      const outside = JSON.parse(fs.readFileSync(outsideMetadata, 'utf-8'));
+      expect(outside.status).toBe('running');
+    });
   });
 
   describe('getSession', () => {
@@ -401,6 +424,19 @@ describe('Session Manager', () => {
         saveSummary(projectDir, 'nonexistent', 'Test summary');
       }).toThrow(/not found/);
     });
+
+    it('rejects a summary symlink before overwriting an outside target', () => {
+      const summaryPath = path.join(projectDir, '.claude', 'sidecar_sessions', 'abc123', 'summary.md');
+      const outsideSummary = path.join(tempDir, 'outside-summary.md');
+      fs.writeFileSync(outsideSummary, 'outside summary');
+      fs.symlinkSync(outsideSummary, summaryPath);
+
+      expect(() => {
+        saveSummary(projectDir, 'abc123', 'escaped summary');
+      }).toThrow(/symbolic link|session directory|outside/i);
+
+      expect(fs.readFileSync(outsideSummary, 'utf-8')).toBe('outside summary');
+    });
   });
 
   describe('SESSION_STATUS', () => {
@@ -495,6 +531,48 @@ describe('Session Manager', () => {
         expect(metadata.backend).toBe('codex');
         expect(metadata.sandboxMode).toBe('read-only');
         expect(metadata.pid).toBe(4321);
+      });
+
+      it('rejects a symlinked sub-agents root before writing outside metadata', () => {
+        const subagentId = 'subagent-root-escape';
+        const parentDir = path.join(projectDir, '.claude', 'sidecar_sessions', parentTaskId);
+        const subagentsRoot = path.join(parentDir, 'subagents');
+        const outsideRoot = path.join(tempDir, 'outside-subagents-root');
+        fs.mkdirSync(outsideRoot, { recursive: true });
+        fs.symlinkSync(outsideRoot, subagentsRoot, 'dir');
+
+        expect(() => {
+          createSubagentSession(projectDir, parentTaskId, subagentId, {
+            agentType: 'general',
+            briefing: 'Do work'
+          });
+        }).toThrow(/symbolic link|sub-agent|outside|session/i);
+
+        expect(fs.existsSync(path.join(outsideRoot, subagentId, 'metadata.json'))).toBe(false);
+      });
+
+      it('rejects a preexisting symlinked sub-agent directory before writing outside metadata', () => {
+        const subagentId = 'subagent-dir-escape';
+        const subagentsRoot = path.join(
+          projectDir, '.claude', 'sidecar_sessions', parentTaskId, 'subagents'
+        );
+        const outsideDir = path.join(tempDir, 'outside-subagent-dir');
+        fs.mkdirSync(subagentsRoot, { recursive: true });
+        fs.mkdirSync(outsideDir, { recursive: true });
+        fs.writeFileSync(path.join(outsideDir, 'metadata.json'), JSON.stringify({
+          status: SESSION_STATUS.RUNNING
+        }));
+        fs.symlinkSync(outsideDir, path.join(subagentsRoot, subagentId), 'dir');
+
+        expect(() => {
+          createSubagentSession(projectDir, parentTaskId, subagentId, {
+            agentType: 'general',
+            briefing: 'Do work'
+          });
+        }).toThrow(/symbolic link|sub-agent|outside|session/i);
+
+        const outside = JSON.parse(fs.readFileSync(path.join(outsideDir, 'metadata.json'), 'utf-8'));
+        expect(outside.status).toBe(SESSION_STATUS.RUNNING);
       });
     });
 

--- a/tests/session-manager.test.js
+++ b/tests/session-manager.test.js
@@ -24,7 +24,8 @@ const {
   updateSubagentSession,
   getSubagentSession,
   listSubagents,
-  saveSubagentSummary
+  saveSubagentSummary,
+  appendSubagentConversation
 } = require('../src/session-manager');
 
 describe('Session Manager', () => {
@@ -451,6 +452,22 @@ describe('Session Manager', () => {
         expect(metadata.briefing).toBe('Audit authentication');
         expect(metadata.status).toBe(SESSION_STATUS.RUNNING);
       });
+
+      it('should preserve optional backend metadata', () => {
+        const subagentId = 'subagent-backend';
+        createSubagentSession(projectDir, parentTaskId, subagentId, {
+          agentType: 'explore',
+          briefing: 'Find auth flows',
+          backend: 'codex',
+          sandboxMode: 'read-only',
+          pid: 4321
+        });
+
+        const metadata = getSubagentSession(projectDir, parentTaskId, subagentId);
+        expect(metadata.backend).toBe('codex');
+        expect(metadata.sandboxMode).toBe('read-only');
+        expect(metadata.pid).toBe(4321);
+      });
     });
 
     describe('updateSubagentSession', () => {
@@ -569,6 +586,27 @@ describe('Session Manager', () => {
         const metadata = getSubagentSession(projectDir, parentTaskId, subagentId);
         expect(metadata.status).toBe(SESSION_STATUS.COMPLETE);
         expect(metadata.completedAt).toBeDefined();
+      });
+    });
+
+    describe('appendSubagentConversation', () => {
+      it('should append a JSONL conversation entry for a sub-agent', () => {
+        const subagentId = 'subagent-conversation';
+        createSubagentSession(projectDir, parentTaskId, subagentId, {
+          agentType: 'general',
+          briefing: 'Do work'
+        });
+
+        appendSubagentConversation(projectDir, parentTaskId, subagentId, {
+          role: 'assistant',
+          content: 'Planning...'
+        });
+
+        const convPath = path.join(
+          projectDir, '.claude', 'sidecar_sessions', parentTaskId, 'subagents', subagentId, 'conversation.jsonl'
+        );
+
+        expect(fs.readFileSync(convPath, 'utf-8')).toContain('Planning...');
       });
     });
   });

--- a/tests/session-manager.test.js
+++ b/tests/session-manager.test.js
@@ -493,6 +493,35 @@ describe('Session Manager', () => {
           updateSubagentSession(projectDir, parentTaskId, 'non-existent', {});
         }).toThrow('Sub-agent non-existent not found');
       });
+
+      it('should reject a symlinked sub-agent directory before writing outside metadata', () => {
+        const subagentId = 'subagent-escape';
+        const subagentsRoot = path.join(
+          projectDir, '.claude', 'sidecar_sessions', parentTaskId, 'subagents'
+        );
+        const outsideDir = path.join(tempDir, 'outside-subagent-metadata');
+        fs.mkdirSync(subagentsRoot, { recursive: true });
+        fs.mkdirSync(outsideDir, { recursive: true });
+        fs.writeFileSync(path.join(outsideDir, 'metadata.json'), JSON.stringify({
+          subagentId,
+          parentTaskId,
+          agentType: 'general',
+          briefing: 'outside',
+          status: SESSION_STATUS.RUNNING
+        }));
+        fs.symlinkSync(outsideDir, path.join(subagentsRoot, subagentId), 'dir');
+
+        expect(() => {
+          updateSubagentSession(projectDir, parentTaskId, subagentId, {
+            status: SESSION_STATUS.ABORTED
+          });
+        }).toThrow(/outside|sub-agent|session/i);
+
+        const outsideMetadata = JSON.parse(
+          fs.readFileSync(path.join(outsideDir, 'metadata.json'), 'utf-8')
+        );
+        expect(outsideMetadata.status).toBe(SESSION_STATUS.RUNNING);
+      });
     });
 
     describe('getSubagentSession', () => {

--- a/tests/session-manager.test.js
+++ b/tests/session-manager.test.js
@@ -122,6 +122,21 @@ describe('Session Manager', () => {
       }).toThrow(/already exists/);
     });
 
+    it('rejects a symlinked sessions root before creating a session outside the project', () => {
+      const taskId = 'root-escape';
+      const claudeDir = path.join(projectDir, '.claude');
+      const outsideSessionsRoot = path.join(tempDir, 'outside-sessions-root');
+      fs.mkdirSync(claudeDir, { recursive: true });
+      fs.mkdirSync(outsideSessionsRoot, { recursive: true });
+      fs.symlinkSync(outsideSessionsRoot, path.join(claudeDir, 'sidecar_sessions'), 'dir');
+
+      expect(() => {
+        createSession(projectDir, taskId, { model: 'test/model', project: projectDir });
+      }).toThrow(/sidecar sessions root|symbolic link|outside/i);
+
+      expect(fs.existsSync(path.join(outsideSessionsRoot, taskId, 'metadata.json'))).toBe(false);
+    });
+
     it('should save thinking level in metadata', () => {
       const taskId = 'thinking-test';
       createSession(projectDir, taskId, {
@@ -312,6 +327,19 @@ describe('Session Manager', () => {
       expect(() => {
         saveConversation(projectDir, 'nonexistent', { role: 'user', content: 'Test' });
       }).toThrow(/not found/);
+    });
+
+    it('rejects a dangling conversation symlink before creating the outside target', () => {
+      const convPath = path.join(projectDir, '.claude', 'sidecar_sessions', 'abc123', 'conversation.jsonl');
+      const outsideTarget = path.join(tempDir, 'outside-conversation.jsonl');
+      fs.unlinkSync(convPath);
+      fs.symlinkSync(outsideTarget, convPath);
+
+      expect(() => {
+        saveConversation(projectDir, 'abc123', { role: 'user', content: 'escape' });
+      }).toThrow(/symbolic link|session directory|outside/i);
+
+      expect(fs.existsSync(outsideTarget)).toBe(false);
     });
   });
 
@@ -636,6 +664,27 @@ describe('Session Manager', () => {
         );
 
         expect(fs.readFileSync(convPath, 'utf-8')).toContain('Planning...');
+      });
+
+      it('rejects a dangling sub-agent conversation symlink before creating the outside target', () => {
+        const subagentId = 'subagent-dangling-conversation';
+        const subagentDir = createSubagentSession(projectDir, parentTaskId, subagentId, {
+          agentType: 'general',
+          briefing: 'Do work'
+        });
+        const convPath = path.join(subagentDir, 'conversation.jsonl');
+        const outsideTarget = path.join(tempDir, 'outside-subagent-conversation.jsonl');
+        fs.unlinkSync(convPath);
+        fs.symlinkSync(outsideTarget, convPath);
+
+        expect(() => {
+          appendSubagentConversation(projectDir, parentTaskId, subagentId, {
+            role: 'assistant',
+            content: 'escape'
+          });
+        }).toThrow(/symbolic link|session directory|outside/i);
+
+        expect(fs.existsSync(outsideTarget)).toBe(false);
       });
     });
   });

--- a/tests/session-manager.test.js
+++ b/tests/session-manager.test.js
@@ -655,6 +655,38 @@ describe('Session Manager', () => {
         expect(subagents).toEqual([]);
       });
 
+      it('should return empty array without reading a symlinked sub-agents root', () => {
+        const parentDir = path.join(projectDir, '.claude', 'sidecar_sessions', parentTaskId);
+        const subagentsRoot = path.join(parentDir, 'subagents');
+        const outsideRoot = path.join(tempDir, 'outside-list-subagents-root');
+        fs.mkdirSync(path.join(outsideRoot, 'outside-subagent'), { recursive: true });
+        fs.writeFileSync(path.join(outsideRoot, 'outside-subagent', 'metadata.json'), JSON.stringify({
+          subagentId: 'outside-subagent',
+          parentTaskId,
+          agentType: 'general',
+          briefing: 'outside',
+          status: SESSION_STATUS.RUNNING
+        }));
+        fs.symlinkSync(outsideRoot, subagentsRoot, 'dir');
+
+        const readdirSpy = jest.spyOn(fs, 'readdirSync');
+        try {
+          const subagents = listSubagents(projectDir, parentTaskId);
+          const readOutsideRoot = readdirSpy.mock.calls.some(([candidate]) => {
+            try {
+              return fs.realpathSync(candidate) === fs.realpathSync(outsideRoot);
+            } catch {
+              return false;
+            }
+          });
+
+          expect(subagents).toEqual([]);
+          expect(readOutsideRoot).toBe(false);
+        } finally {
+          readdirSpy.mockRestore();
+        }
+      });
+
       it('should list all sub-agents', () => {
         createSubagentSession(projectDir, parentTaskId, 'subagent-1', {
           agentType: 'general',

--- a/tests/sidecar/context-builder.test.js
+++ b/tests/sidecar/context-builder.test.js
@@ -2,8 +2,8 @@
  * Context Builder Tests
  *
  * Tests for buildContext() with multi-environment support.
- * Validates that context can be built from arbitrary session directories
- * (not just the default ~/.claude/projects/ path).
+ * Validates that context can be built from explicit session directories
+ * when they remain inside the validated project boundary.
  */
 
 const path = require('path');

--- a/tests/sidecar/context-builder.test.js
+++ b/tests/sidecar/context-builder.test.js
@@ -144,6 +144,67 @@ describe('Context Builder', () => {
       expect(context).not.toContain('user message 0');
       fs.rmSync(tmpDir, { recursive: true });
     });
+
+    it('should reject current when exactSession is requested with sessionDir', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-ctx-exact-'));
+      fs.writeFileSync(path.join(tmpDir, 'newest-session.jsonl'), JSON.stringify({
+        type: 'user',
+        message: { content: 'newest fallback should not be used' },
+        timestamp: new Date().toISOString()
+      }) + '\n');
+
+      try {
+        expect(() => buildContext(tmpDir, 'current', {
+          sessionDir: tmpDir,
+          exactSession: true
+        })).toThrow(/exact session/i);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should reject nonexistent exact session instead of falling back to most recent', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-ctx-exact-'));
+      fs.writeFileSync(path.join(tmpDir, 'newest-session.jsonl'), JSON.stringify({
+        type: 'user',
+        message: { content: 'newest fallback should not be used' },
+        timestamp: new Date().toISOString()
+      }) + '\n');
+
+      try {
+        expect(() => buildContext(tmpDir, 'missing-session', {
+          sessionDir: tmpDir,
+          exactSession: true
+        })).toThrow(/missing-session|not found/i);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should read the requested file when exactSession is requested with an existing session', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-ctx-exact-'));
+      fs.writeFileSync(path.join(tmpDir, 'target-session.jsonl'), JSON.stringify({
+        type: 'user',
+        message: { content: 'target exact context' },
+        timestamp: new Date().toISOString()
+      }) + '\n');
+      fs.writeFileSync(path.join(tmpDir, 'newest-session.jsonl'), JSON.stringify({
+        type: 'user',
+        message: { content: 'newest fallback should not be used' },
+        timestamp: new Date().toISOString()
+      }) + '\n');
+
+      try {
+        const context = buildContext(tmpDir, 'target-session', {
+          sessionDir: tmpDir,
+          exactSession: true
+        });
+        expect(context).toContain('target exact context');
+        expect(context).not.toContain('newest fallback should not be used');
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('buildContext default behavior', () => {

--- a/tests/sidecar/context-builder.test.js
+++ b/tests/sidecar/context-builder.test.js
@@ -404,6 +404,21 @@ describe('Context Builder', () => {
       fs.rmSync(tmpHome, { recursive: true });
     });
 
+    it('should reject a missing coworkProcess match when exactSession is required', () => {
+      const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-cowork-'));
+
+      try {
+        expect(() => buildContext('/Users/john_renaldi', null, {
+          client: 'cowork',
+          coworkProcess: 'fake-process',
+          exactSession: true,
+          _homeDir: tmpHome
+        })).toThrow(/Cowork session.*fake-process.*not found/i);
+      } finally {
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+      }
+    });
+
     it('should match correct session when coworkProcess is provided', () => {
       const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-cowork-'));
       const sessRoot = path.join(tmpHome, 'Library', 'Application Support', 'Claude', 'local-agent-mode-sessions');

--- a/tests/sidecar/context-builder.test.js
+++ b/tests/sidecar/context-builder.test.js
@@ -83,7 +83,6 @@ describe('Context Builder', () => {
     });
 
     it('should use sessionDir over default path resolution when both could apply', () => {
-      // Even with a real project path, sessionDir should take precedence
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-ctx-test-'));
       const sessionFile = path.join(tmpDir, 'priority-session.jsonl');
       fs.writeFileSync(sessionFile, JSON.stringify({
@@ -92,14 +91,15 @@ describe('Context Builder', () => {
         timestamp: new Date().toISOString()
       }) + '\n');
 
-      const context = buildContext('/some/project', 'priority-session', { sessionDir: tmpDir });
+      const context = buildContext(tmpDir, 'priority-session', { sessionDir: tmpDir });
       expect(context).toContain('from explicit session dir');
       fs.rmSync(tmpDir, { recursive: true });
     });
 
-    it('should handle missing sessionDir gracefully', () => {
-      const context = buildContext('/nonexistent', null, { sessionDir: '/nonexistent/session/dir' });
-      expect(context).toContain('No Claude Code conversation history');
+    it('should reject missing sessionDir when explicitly provided', () => {
+      expect(() => buildContext('/nonexistent', null, {
+        sessionDir: '/nonexistent/session/dir'
+      })).toThrow(/project root|session directory/i);
     });
 
     it('should handle empty session file in sessionDir', () => {
@@ -316,9 +316,12 @@ describe('Context Builder', () => {
         JSON.stringify({ type: 'rate_limit_event', _audit_timestamp: new Date().toISOString() }),
       ];
       fs.writeFileSync(path.join(sessDir, 'audit.jsonl'), lines.join('\n') + '\n');
+      fs.writeFileSync(path.join(sessRoot, 'org-1', 'user-1', 'local_test-session.json'),
+        JSON.stringify({ processName: 'target-process' }));
 
       const context = buildContext('/Users/john_renaldi', null, {
         client: 'cowork',
+        coworkProcess: 'target-process',
         _homeDir: tmpHome
       });
       expect(context).toContain('cowork parent context');
@@ -333,6 +336,7 @@ describe('Context Builder', () => {
 
       const context = buildContext('/Users/john_renaldi', null, {
         client: 'cowork',
+        coworkProcess: 'missing-process',
         _homeDir: tmpHome
       });
       expect(context).toContain('No Claude Code conversation history');
@@ -383,9 +387,12 @@ describe('Context Builder', () => {
         lines.push(JSON.stringify({ type: 'assistant', message: { content: `reply ${i}` }, _audit_timestamp: new Date().toISOString() }));
       }
       fs.writeFileSync(path.join(sessDir, 'audit.jsonl'), lines.join('\n') + '\n');
+      fs.writeFileSync(path.join(sessRoot, 'org-1', 'user-1', 'local_test-session.json'),
+        JSON.stringify({ processName: 'filter-target' }));
 
       const context = buildContext('/Users/john_renaldi', null, {
         client: 'cowork',
+        coworkProcess: 'filter-target',
         _homeDir: tmpHome,
         contextTurns: 2
       });

--- a/tests/sidecar/continue.test.js
+++ b/tests/sidecar/continue.test.js
@@ -95,4 +95,49 @@ describe('Continue Operations session boundary validation', () => {
     expect(fs.statSync(sessionDir).mode & 0o777).toBe(0o700);
     expect(fs.statSync(metaPath).mode & 0o777).toBe(0o600);
   });
+
+  test('createContinueSessionMetadata rejects a symlinked sessions root before writing outside metadata', () => {
+    const { createContinueSessionMetadata } = require('../../src/sidecar/continue');
+    const claudeDir = path.join(projectDir, '.claude');
+    const outsideRoot = path.join(otherProjectDir, 'outside-sessions-root');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.mkdirSync(outsideRoot, { recursive: true });
+    fs.symlinkSync(outsideRoot, path.join(claudeDir, 'sidecar_sessions'), 'dir');
+
+    expect(() => {
+      createContinueSessionMetadata('root-escape', projectDir, {
+        model: 'google/gemini-test',
+        briefing: 'follow up',
+        headless: true,
+        agent: 'build'
+      }, 'old-task');
+    }).toThrow(/sidecar sessions root|symbolic link|outside/i);
+
+    expect(fs.existsSync(path.join(outsideRoot, 'root-escape', 'metadata.json'))).toBe(false);
+  });
+
+  test('createContinueSessionMetadata rejects a preexisting symlinked task directory', () => {
+    const { createContinueSessionMetadata } = require('../../src/sidecar/continue');
+    const sessionsRoot = path.join(projectDir, '.claude', 'sidecar_sessions');
+    const outsideSession = path.join(otherProjectDir, 'outside-session');
+    fs.mkdirSync(sessionsRoot, { recursive: true });
+    fs.mkdirSync(outsideSession, { recursive: true });
+    fs.writeFileSync(path.join(outsideSession, 'metadata.json'), JSON.stringify({
+      taskId: 'new-task',
+      status: 'running'
+    }));
+    fs.symlinkSync(outsideSession, path.join(sessionsRoot, 'new-task'), 'dir');
+
+    expect(() => {
+      createContinueSessionMetadata('new-task', projectDir, {
+        model: 'google/gemini-test',
+        briefing: 'follow up',
+        headless: true,
+        agent: 'build'
+      }, 'old-task');
+    }).toThrow(/session directory|symbolic link|outside/i);
+
+    const outside = JSON.parse(fs.readFileSync(path.join(outsideSession, 'metadata.json'), 'utf-8'));
+    expect(outside.status).toBe('running');
+  });
 });

--- a/tests/sidecar/continue.test.js
+++ b/tests/sidecar/continue.test.js
@@ -52,4 +52,47 @@ describe('Continue Operations session boundary validation', () => {
 
     expect(() => loadPreviousSession('old-task', projectDir)).toThrow(/project/i);
   });
+
+  test('loadPreviousSession rejects a summary file symlink that escapes the session directory', () => {
+    const sessionDir = path.join(projectDir, '.claude', 'sidecar_sessions', 'old-task');
+    const outsideSummary = path.join(otherProjectDir, 'summary.md');
+    writeSession(sessionDir, fs.realpathSync(projectDir));
+    fs.writeFileSync(outsideSummary, 'external secret summary');
+    fs.unlinkSync(path.join(sessionDir, 'summary.md'));
+    fs.symlinkSync(outsideSummary, path.join(sessionDir, 'summary.md'));
+
+    expect(() => loadPreviousSession('old-task', projectDir)).toThrow(/outside|session directory/i);
+  });
+
+  test('loadPreviousSession rejects a conversation file symlink that escapes the session directory', () => {
+    const sessionDir = path.join(projectDir, '.claude', 'sidecar_sessions', 'old-task');
+    const outsideConversation = path.join(otherProjectDir, 'conversation.jsonl');
+    writeSession(sessionDir, fs.realpathSync(projectDir));
+    fs.writeFileSync(outsideConversation,
+      JSON.stringify({ role: 'assistant', content: 'external secret conversation' }) + '\n');
+    fs.unlinkSync(path.join(sessionDir, 'conversation.jsonl'));
+    fs.symlinkSync(outsideConversation, path.join(sessionDir, 'conversation.jsonl'));
+
+    expect(() => loadPreviousSession('old-task', projectDir)).toThrow(/outside|session directory/i);
+  });
+
+  test('createContinueSessionMetadata enforces private directory and metadata modes for existing paths', () => {
+    const { createContinueSessionMetadata } = require('../../src/sidecar/continue');
+    const sessionDir = path.join(projectDir, '.claude', 'sidecar_sessions', 'new-task');
+    const metaPath = path.join(sessionDir, 'metadata.json');
+    fs.mkdirSync(sessionDir, { recursive: true, mode: 0o755 });
+    fs.chmodSync(sessionDir, 0o755);
+    fs.writeFileSync(metaPath, '{}', { mode: 0o644 });
+    fs.chmodSync(metaPath, 0o644);
+
+    createContinueSessionMetadata('new-task', projectDir, {
+      model: 'google/gemini-test',
+      briefing: 'follow up',
+      headless: true,
+      agent: 'build'
+    }, 'old-task');
+
+    expect(fs.statSync(sessionDir).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(metaPath).mode & 0o777).toBe(0o600);
+  });
 });

--- a/tests/sidecar/continue.test.js
+++ b/tests/sidecar/continue.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { loadPreviousSession } = require('../../src/sidecar/continue');
+
+describe('Continue Operations session boundary validation', () => {
+  let projectDir;
+  let otherProjectDir;
+
+  beforeEach(() => {
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-continue-project-'));
+    otherProjectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-continue-other-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(otherProjectDir, { recursive: true, force: true });
+  });
+
+  function writeSession(sessionDir, metadataProject) {
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(path.join(sessionDir, 'metadata.json'), JSON.stringify({
+      taskId: 'old-task',
+      project: metadataProject,
+      projectDir: metadataProject,
+      briefing: 'external secret briefing',
+      status: 'complete',
+      createdAt: new Date().toISOString()
+    }));
+    fs.writeFileSync(path.join(sessionDir, 'summary.md'), 'external secret summary');
+    fs.writeFileSync(path.join(sessionDir, 'conversation.jsonl'),
+      JSON.stringify({ role: 'assistant', content: 'external secret conversation' }) + '\n');
+  }
+
+  test('loadPreviousSession rejects a task directory symlink that escapes the project sessions root', () => {
+    const externalSessionDir = path.join(otherProjectDir, '.claude', 'sidecar_sessions', 'old-task');
+    writeSession(externalSessionDir, fs.realpathSync(otherProjectDir));
+
+    const sessionsRoot = path.join(projectDir, '.claude', 'sidecar_sessions');
+    fs.mkdirSync(sessionsRoot, { recursive: true });
+    fs.symlinkSync(externalSessionDir, path.join(sessionsRoot, 'old-task'), 'dir');
+
+    expect(() => loadPreviousSession('old-task', projectDir)).toThrow(/outside|session root/i);
+  });
+
+  test('loadPreviousSession rejects metadata bound to a different project before reading prior context', () => {
+    const sessionDir = path.join(projectDir, '.claude', 'sidecar_sessions', 'old-task');
+    writeSession(sessionDir, fs.realpathSync(otherProjectDir));
+
+    expect(() => loadPreviousSession('old-task', projectDir)).toThrow(/project/i);
+  });
+});

--- a/tests/sidecar/exit-handler.test.js
+++ b/tests/sidecar/exit-handler.test.js
@@ -87,4 +87,32 @@ describe('Crash Handler', () => {
     expect(updated.reason).toBeUndefined();
     expect(updated.errorAt).toBeUndefined();
   });
+
+  it('does not follow a metadata symlink to update an outside target', () => {
+    const taskId = 'task-crash-symlink';
+    const sessionDir = SessionPaths.sessionDir(tmpDir, taskId);
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'crash-handler-outside-'));
+    const outsideMetadata = path.join(outsideDir, 'metadata.json');
+
+    try {
+      fs.mkdirSync(sessionDir, { recursive: true });
+      fs.writeFileSync(outsideMetadata, JSON.stringify({
+        taskId,
+        status: 'running',
+        model: 'outside-model',
+        createdAt: new Date().toISOString()
+      }, null, 2));
+      fs.symlinkSync(outsideMetadata, SessionPaths.metadataFile(sessionDir));
+
+      const handler = installCrashHandler(taskId, tmpDir);
+      expect(() => handler(new Error('outside crash'))).not.toThrow();
+
+      const outside = JSON.parse(fs.readFileSync(outsideMetadata, 'utf-8'));
+      expect(outside.status).toBe('running');
+      expect(outside.reason).toBeUndefined();
+      expect(outside.errorAt).toBeUndefined();
+    } finally {
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/sidecar/interactive.test.js
+++ b/tests/sidecar/interactive.test.js
@@ -38,12 +38,37 @@ describe('buildElectronEnv - window position', () => {
     const env = buildElectronEnv(...BASE_ARGS, {});
     expect(env.SIDECAR_WINDOW_POSITION).toBeUndefined();
   });
+
+  it('does not copy ambient API credentials into the Electron process env', () => {
+    const originalEnv = { ...process.env };
+    try {
+      process.env.OPENAI_API_KEY = 'openai-secret';
+      process.env.ANTHROPIC_API_KEY = 'anthropic-secret';
+      process.env.SIDECAR_ENV_DIR = '/tmp/sidecar-env-dir';
+      process.env.LOG_LEVEL = 'debug';
+
+      const env = buildElectronEnv(...BASE_ARGS, {});
+
+      expect(env.PATH).toBe('/bin:/usr/bin');
+      expect(env.SIDECAR_ENV_DIR).toBe('/tmp/sidecar-env-dir');
+      expect(env.LOG_LEVEL).toBe('debug');
+      expect(env.OPENAI_API_KEY).toBeUndefined();
+      expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    } finally {
+      process.env = originalEnv;
+    }
+  });
 });
 
 describe('getElectronPath', () => {
   it('returns the path from require("electron") instead of hardcoded relative path', () => {
-    const { getElectronPath } = require('../../src/sidecar/interactive');
+    const { checkElectronAvailable, getElectronPath } = require('../../src/sidecar/interactive');
     const result = getElectronPath();
+
+    if (result === null) {
+      expect(checkElectronAvailable()).toBe(false);
+      return;
+    }
 
     // Should NOT be a hardcoded node_modules/.bin/electron path
     expect(result).not.toContain('node_modules/.bin/electron');

--- a/tests/sidecar/progress.test.js
+++ b/tests/sidecar/progress.test.js
@@ -169,6 +169,38 @@ describe('Progress Reader', () => {
       // Should use last valid assistant entry
       expect(result.latest).toBe('Using Bash');
     });
+
+    it('ignores symlinked progress inputs that resolve outside the session directory', () => {
+      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'progress-outside-'));
+      try {
+        fs.writeFileSync(
+          path.join(outsideDir, 'conversation.jsonl'),
+          JSON.stringify({ role: 'assistant', content: 'outside secret progress' }) + '\n'
+        );
+        fs.writeFileSync(
+          path.join(outsideDir, 'progress.json'),
+          JSON.stringify({
+            stage: 'receiving',
+            stageLabel: 'outside secret stage',
+            updatedAt: new Date().toISOString()
+          })
+        );
+        fs.symlinkSync(path.join(outsideDir, 'conversation.jsonl'), path.join(tmpDir, 'conversation.jsonl'));
+        fs.symlinkSync(path.join(outsideDir, 'progress.json'), path.join(tmpDir, 'progress.json'));
+
+        const result = readProgress(tmpDir);
+
+        expect(result).toMatchObject({
+          messages: 0,
+          lastActivity: 'never',
+          latest: 'Starting up...',
+          lastActivityMs: null
+        });
+        expect(result.stage).toBeUndefined();
+      } finally {
+        fs.rmSync(outsideDir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('extractLatest', () => {

--- a/tests/sidecar/read.test.js
+++ b/tests/sidecar/read.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { listSidecars, readSidecar } = require('../../src/sidecar/read');
+
+describe('sidecar read/list boundaries', () => {
+  let tmpDir;
+  let outsideDir;
+  let logSpy;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-read-test-'));
+    outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-read-outside-'));
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  test('readSidecar rejects a symlinked task directory before printing outside summary', async () => {
+    const sessionsDir = path.join(tmpDir, '.claude', 'sidecar_sessions');
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    fs.writeFileSync(path.join(outsideDir, 'metadata.json'), JSON.stringify({
+      taskId: 'leak',
+      status: 'complete',
+      createdAt: '2026-03-04T00:00:00Z'
+    }));
+    fs.writeFileSync(path.join(outsideDir, 'summary.md'), 'outside secret summary');
+    fs.symlinkSync(outsideDir, path.join(sessionsDir, 'leak'), 'dir');
+
+    await expect(readSidecar({ taskId: 'leak', project: tmpDir }))
+      .rejects.toThrow(/outside|session root|session directory/i);
+
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('outside secret summary'));
+  });
+
+  test('readSidecar rejects a symlinked conversation file before printing outside content', async () => {
+    const sessDir = path.join(tmpDir, '.claude', 'sidecar_sessions', 'convleak');
+    fs.mkdirSync(sessDir, { recursive: true });
+    fs.writeFileSync(path.join(sessDir, 'metadata.json'), JSON.stringify({
+      taskId: 'convleak',
+      status: 'complete',
+      createdAt: '2026-03-04T00:00:00Z'
+    }));
+    const outsideConversation = path.join(outsideDir, 'conversation.jsonl');
+    fs.writeFileSync(
+      outsideConversation,
+      JSON.stringify({ role: 'assistant', content: 'outside secret conversation' }) + '\n'
+    );
+    fs.symlinkSync(outsideConversation, path.join(sessDir, 'conversation.jsonl'));
+
+    await expect(readSidecar({ taskId: 'convleak', project: tmpDir, conversation: true }))
+      .rejects.toThrow(/outside|session directory/i);
+
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('outside secret conversation'));
+  });
+
+  test('listSidecars skips symlinked task directories instead of printing outside metadata', async () => {
+    const sessionsDir = path.join(tmpDir, '.claude', 'sidecar_sessions');
+    const validDir = path.join(sessionsDir, 'valid-task');
+    fs.mkdirSync(validDir, { recursive: true });
+    fs.writeFileSync(path.join(validDir, 'metadata.json'), JSON.stringify({
+      taskId: 'valid-task',
+      model: 'gemini',
+      status: 'complete',
+      briefing: 'inside session',
+      createdAt: '2026-03-04T00:00:00Z'
+    }));
+    fs.writeFileSync(path.join(outsideDir, 'metadata.json'), JSON.stringify({
+      taskId: 'leak',
+      model: 'outside-model',
+      status: 'complete',
+      briefing: 'outside secret briefing',
+      createdAt: '2026-03-05T00:00:00Z'
+    }));
+    fs.symlinkSync(outsideDir, path.join(sessionsDir, 'leak'), 'dir');
+
+    await listSidecars({ project: tmpDir, json: true });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(parsed.map(s => s.id)).toEqual(['valid-task']);
+    expect(logSpy.mock.calls[0][0]).not.toContain('outside secret briefing');
+    expect(logSpy.mock.calls[0][0]).not.toContain('outside-model');
+  });
+});

--- a/tests/sidecar/resume.test.js
+++ b/tests/sidecar/resume.test.js
@@ -141,6 +141,28 @@ describe('Resume Operations', () => {
       expect(updated.status).toBe('running');
       expect(updated.resumedAt).toBeDefined();
     });
+
+    it('rejects a metadata symlink before updating an outside target', () => {
+      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-resume-meta-outside-'));
+      const outsideMetadata = path.join(outsideDir, 'metadata.json');
+
+      try {
+        fs.writeFileSync(outsideMetadata, JSON.stringify({
+          taskId: 'abc123',
+          status: 'complete'
+        }));
+        fs.symlinkSync(outsideMetadata, path.join(tmpDir, 'metadata.json'));
+
+        expect(() => updateSessionStatus(tmpDir, 'running'))
+          .toThrow(/symbolic link|session directory|outside/i);
+
+        const outside = JSON.parse(fs.readFileSync(outsideMetadata, 'utf-8'));
+        expect(outside.status).toBe('complete');
+        expect(outside.resumedAt).toBeUndefined();
+      } finally {
+        fs.rmSync(outsideDir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('buildResumeUserMessage', () => {

--- a/tests/sidecar/resume.test.js
+++ b/tests/sidecar/resume.test.js
@@ -71,6 +71,20 @@ describe('Resume Operations', () => {
       const context = loadInitialContext(tmpDir);
       expect(context).toBe('');
     });
+
+    it('should reject an initial context symlink that escapes the session directory', () => {
+      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-resume-outside-'));
+      const outsideContext = path.join(outsideDir, 'initial_context.md');
+
+      try {
+        fs.writeFileSync(outsideContext, 'external secret context');
+        fs.symlinkSync(outsideContext, path.join(tmpDir, 'initial_context.md'));
+
+        expect(() => loadInitialContext(tmpDir)).toThrow(/outside|session directory/i);
+      } finally {
+        fs.rmSync(outsideDir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('checkFileDrift', () => {
@@ -263,6 +277,18 @@ describe('Resume Operations', () => {
       writeSession(sessionDir, fs.realpathSync(otherProjectDir));
 
       await expectResumeRejected(/project/i);
+    });
+
+    it('rejects a conversation file symlink that escapes the session directory', async () => {
+      const sessionDir = path.join(projectDir, '.claude', 'sidecar_sessions', 'resume-task');
+      const outsideConversation = path.join(otherProjectDir, 'conversation.jsonl');
+      writeSession(sessionDir, fs.realpathSync(projectDir));
+      fs.writeFileSync(outsideConversation,
+        JSON.stringify({ role: 'assistant', content: 'external secret conversation' }) + '\n');
+      fs.unlinkSync(path.join(sessionDir, 'conversation.jsonl'));
+      fs.symlinkSync(outsideConversation, path.join(sessionDir, 'conversation.jsonl'));
+
+      await expectResumeRejected(/outside|session directory/i);
     });
   });
 });

--- a/tests/sidecar/resume.test.js
+++ b/tests/sidecar/resume.test.js
@@ -190,4 +190,79 @@ describe('Resume Operations', () => {
       expect(loaded.opencodeSessionId).toBeUndefined();
     });
   });
+
+  describe('resumeSidecar session boundary validation', () => {
+    let projectDir;
+    let otherProjectDir;
+
+    beforeEach(() => {
+      projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-resume-project-'));
+      otherProjectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-resume-other-'));
+    });
+
+    afterEach(() => {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+      fs.rmSync(otherProjectDir, { recursive: true, force: true });
+      jest.resetModules();
+    });
+
+    function writeSession(sessionDir, metadataProject) {
+      fs.mkdirSync(sessionDir, { recursive: true });
+      fs.writeFileSync(path.join(sessionDir, 'metadata.json'), JSON.stringify({
+        taskId: 'resume-task',
+        project: metadataProject,
+        projectDir: metadataProject,
+        model: 'google/gemini-test',
+        agent: 'build',
+        briefing: 'resume external secret',
+        status: 'complete',
+        pid: null,
+        createdAt: new Date().toISOString()
+      }));
+      fs.writeFileSync(path.join(sessionDir, 'initial_context.md'), 'external secret context');
+      fs.writeFileSync(path.join(sessionDir, 'conversation.jsonl'),
+        JSON.stringify({ role: 'assistant', content: 'external secret conversation' }) + '\n');
+    }
+
+    async function expectResumeRejected(expectedPattern) {
+      await jest.isolateModulesAsync(async () => {
+        jest.doMock('../../src/sidecar/start', () => ({
+          runInteractive: jest.fn(async () => ({ summary: 'done' })),
+          buildMcpConfig: jest.fn(() => null)
+        }));
+        jest.doMock('../../src/headless', () => ({
+          runHeadless: jest.fn(async () => ({ summary: 'done' }))
+        }));
+        jest.doMock('../../src/utils/session-lock', () => ({
+          acquireLock: jest.fn(),
+          releaseLock: jest.fn()
+        }));
+
+        const { resumeSidecar } = require('../../src/sidecar/resume');
+        await expect(resumeSidecar({
+          taskId: 'resume-task',
+          project: projectDir,
+          headless: true
+        })).rejects.toThrow(expectedPattern);
+      });
+    }
+
+    it('rejects a task directory symlink that escapes the project sessions root', async () => {
+      const externalSessionDir = path.join(otherProjectDir, '.claude', 'sidecar_sessions', 'resume-task');
+      writeSession(externalSessionDir, fs.realpathSync(otherProjectDir));
+
+      const sessionsRoot = path.join(projectDir, '.claude', 'sidecar_sessions');
+      fs.mkdirSync(sessionsRoot, { recursive: true });
+      fs.symlinkSync(externalSessionDir, path.join(sessionsRoot, 'resume-task'), 'dir');
+
+      await expectResumeRejected(/outside|session root/i);
+    });
+
+    it('rejects metadata bound to a different project before loading prior context', async () => {
+      const sessionDir = path.join(projectDir, '.claude', 'sidecar_sessions', 'resume-task');
+      writeSession(sessionDir, fs.realpathSync(otherProjectDir));
+
+      await expectResumeRejected(/project/i);
+    });
+  });
 });

--- a/tests/sidecar/session-utils.test.js
+++ b/tests/sidecar/session-utils.test.js
@@ -7,6 +7,7 @@
 
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 
 jest.mock('../../src/conflict', () => ({
   detectConflicts: jest.fn().mockReturnValue([]),
@@ -104,21 +105,22 @@ describe('Session Utils', () => {
   });
 
   describe('finalizeSession', () => {
-    let writeFileSyncSpy;
+    let project;
+    let sessDir;
 
     beforeEach(() => {
-      writeFileSyncSpy = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+      project = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-finalize-project-'));
+      sessDir = path.join(project, '.claude', 'sidecar_sessions', 'task-1');
+      fs.mkdirSync(sessDir, { recursive: true });
       detectConflicts.mockReturnValue([]);
     });
 
     afterEach(() => {
-      writeFileSyncSpy.mockRestore();
+      fs.rmSync(project, { recursive: true, force: true });
     });
 
     it('should save summary and update metadata to complete', () => {
-      const sessDir = '/tmp/test-session';
       const summary = '## Results\n\nDone';
-      const project = '/test/project';
       const metadata = {
         taskId: 'task-1',
         filesWritten: [],
@@ -127,19 +129,8 @@ describe('Session Utils', () => {
 
       finalizeSession(sessDir, summary, project, metadata);
 
-      // Should write summary.md
-      expect(writeFileSyncSpy).toHaveBeenCalledWith(
-        path.join(sessDir, 'summary.md'),
-        summary,
-        { mode: 0o600 }
-      );
-
-      // Should write metadata.json with status=complete
-      const metaCall = writeFileSyncSpy.mock.calls.find(
-        c => c[0] === path.join(sessDir, 'metadata.json')
-      );
-      expect(metaCall).toBeTruthy();
-      const savedMeta = JSON.parse(metaCall[1]);
+      expect(fs.readFileSync(path.join(sessDir, 'summary.md'), 'utf-8')).toBe(summary);
+      const savedMeta = JSON.parse(fs.readFileSync(path.join(sessDir, 'metadata.json'), 'utf-8'));
       expect(savedMeta.status).toBe('complete');
       expect(savedMeta.completedAt).toBeDefined();
     });
@@ -148,7 +139,6 @@ describe('Session Utils', () => {
       const conflicts = [{ file: 'src/foo.js', type: 'external_edit' }];
       detectConflicts.mockReturnValue(conflicts);
 
-      const sessDir = '/tmp/test-session';
       const metadata = {
         taskId: 'task-2',
         filesWritten: ['src/foo.js'],
@@ -156,10 +146,30 @@ describe('Session Utils', () => {
       };
 
       const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-      finalizeSession(sessDir, 'summary', '/project', metadata);
+      finalizeSession(sessDir, 'summary', project, metadata);
       consoleSpy.mockRestore();
 
       expect(metadata.conflicts).toEqual(conflicts);
+    });
+
+    it('rejects a summary symlink that escapes the session directory without modifying the target', () => {
+      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-finalize-outside-'));
+      const outsideSummary = path.join(outsideDir, 'summary.md');
+
+      try {
+        fs.writeFileSync(outsideSummary, 'outside summary untouched');
+        fs.symlinkSync(outsideSummary, path.join(sessDir, 'summary.md'));
+
+        expect(() => finalizeSession(sessDir, 'new summary', project, {
+          taskId: 'summary-link',
+          filesWritten: [],
+          createdAt: new Date().toISOString()
+        })).toThrow(/outside|session directory/i);
+
+        expect(fs.readFileSync(outsideSummary, 'utf-8')).toBe('outside summary untouched');
+      } finally {
+        fs.rmSync(outsideDir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/tests/sidecar/session-utils.test.js
+++ b/tests/sidecar/session-utils.test.js
@@ -89,18 +89,56 @@ describe('Session Utils', () => {
 
   describe('saveInitialContext', () => {
     it('should write system prompt and user message to initial_context.md', () => {
-      const sessDir = '/tmp/test-session';
-      const spy = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+      const sessDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-context-session-'));
 
-      saveInitialContext(sessDir, 'System prompt here', 'User message here');
+      try {
+        saveInitialContext(sessDir, 'System prompt here', 'User message here');
 
-      expect(spy).toHaveBeenCalledWith(
-        path.join(sessDir, 'initial_context.md'),
-        '# System Prompt\n\nSystem prompt here\n\n# User Message (Task)\n\nUser message here',
-        { mode: 0o600 }
-      );
+        expect(fs.readFileSync(path.join(sessDir, 'initial_context.md'), 'utf-8')).toBe(
+          '# System Prompt\n\nSystem prompt here\n\n# User Message (Task)\n\nUser message here'
+        );
+      } finally {
+        fs.rmSync(sessDir, { recursive: true, force: true });
+      }
+    });
 
-      spy.mockRestore();
+    it('rejects an initial_context.md symlink without modifying the outside target', () => {
+      const sessDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-context-session-'));
+      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-context-outside-'));
+      const outsideContext = path.join(outsideDir, 'initial_context.md');
+
+      try {
+        fs.writeFileSync(outsideContext, 'outside context untouched');
+        fs.symlinkSync(outsideContext, path.join(sessDir, 'initial_context.md'));
+
+        expect(() => {
+          saveInitialContext(sessDir, 'System prompt here', 'User message here');
+        }).toThrow(/symbolic link|session directory|outside/i);
+
+        expect(fs.readFileSync(outsideContext, 'utf-8')).toBe('outside context untouched');
+      } finally {
+        fs.rmSync(sessDir, { recursive: true, force: true });
+        fs.rmSync(outsideDir, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects a dangling initial_context.md symlink before creating the outside target', () => {
+      const sessDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-context-session-'));
+      const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-context-outside-'));
+      const outsideContext = path.join(outsideDir, 'new-initial-context.md');
+
+      try {
+        fs.symlinkSync(outsideContext, path.join(sessDir, 'initial_context.md'));
+
+        expect(() => {
+          saveInitialContext(sessDir, 'System prompt here', 'User message here');
+        }).toThrow(/symbolic link|session directory|outside/i);
+
+        expect(fs.existsSync(outsideContext)).toBe(false);
+      } finally {
+        fs.rmSync(sessDir, { recursive: true, force: true });
+        fs.rmSync(outsideDir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/tests/sidecar/setup-window.test.js
+++ b/tests/sidecar/setup-window.test.js
@@ -23,6 +23,7 @@ describe('setup-window', () => {
   let mockProcess;
 
   beforeEach(() => {
+    spawn.mockClear();
     mockProcess = {
       stdout: {
         on: jest.fn(),
@@ -61,6 +62,33 @@ describe('setup-window', () => {
     expect(env.SIDECAR_MODE).toBe('setup');
 
     expect(result.success).toBe(true);
+  });
+
+  it('should not copy ambient API credentials into the setup Electron env', async () => {
+    const originalEnv = { ...process.env };
+    try {
+      process.env.OPENAI_API_KEY = 'openai-secret';
+      process.env.ANTHROPIC_API_KEY = 'anthropic-secret';
+      process.env.SIDECAR_ENV_DIR = '/tmp/sidecar-env-dir';
+
+      const promise = launchSetupWindow();
+
+      const dataCallback = mockProcess.stdout.on.mock.calls.find(c => c[0] === 'data')[1];
+      dataCallback('{"status":"complete"}\n');
+
+      const closeCallback = mockProcess.on.mock.calls.find(c => c[0] === 'close')[1];
+      closeCallback(0);
+
+      await promise;
+
+      const env = spawn.mock.calls[0][2].env;
+      expect(env.SIDECAR_MODE).toBe('setup');
+      expect(env.SIDECAR_ENV_DIR).toBe('/tmp/sidecar-env-dir');
+      expect(env.OPENAI_API_KEY).toBeUndefined();
+      expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    } finally {
+      process.env = originalEnv;
+    }
   });
 
   it('should pass --remote-debugging-port when SIDECAR_DEBUG_PORT is set', async () => {

--- a/tests/sidecar/start.test.js
+++ b/tests/sidecar/start.test.js
@@ -247,6 +247,77 @@ describe('createSessionMetadata PID preservation', () => {
   });
 });
 
+describe('startSidecar context binding validation', () => {
+  let tmpDir;
+  let mockSessionDir;
+  const repoRoot = fs.realpathSync(path.resolve(__dirname, '../..'));
+
+  beforeEach(() => {
+    jest.resetModules();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'start-context-binding-'));
+    mockSessionDir = path.join(tmpDir, 'session');
+
+    jest.doMock('../../src/sidecar/context-builder', () => ({
+      buildContext: jest.fn(() => 'mocked context')
+    }));
+    jest.doMock('../../src/prompt-builder', () => ({
+      buildPrompts: jest.fn(() => ({
+        system: 'sys',
+        userMessage: 'user'
+      }))
+    }));
+    jest.doMock('../../src/sidecar/session-utils', () => ({
+      SessionPaths: {
+        sessionDir: jest.fn(() => mockSessionDir),
+        metadataFile: jest.fn((sessionDir) => path.join(sessionDir, 'metadata.json'))
+      },
+      saveInitialContext: jest.fn(),
+      finalizeSession: jest.fn(),
+      outputSummary: jest.fn(),
+      createHeartbeat: jest.fn(() => ({ stop: jest.fn() })),
+      HEARTBEAT_INTERVAL: 5000
+    }));
+    jest.doMock('../../src/sidecar/interactive', () => ({
+      runInteractive: jest.fn(() => ({ summary: 'done' })),
+      checkElectronAvailable: jest.fn()
+    }));
+    jest.doMock('../../src/headless', () => ({
+      runHeadless: jest.fn(() => ({ summary: 'done' }))
+    }));
+    jest.doMock('../../src/opencode-client', () => ({
+      loadMcpConfig: jest.fn(() => null),
+      parseMcpSpec: jest.fn(() => null)
+    }));
+    jest.doMock('../../src/utils/agent-mapping', () => ({
+      mapAgentToOpenCode: jest.fn(() => ({ agent: 'Build' }))
+    }));
+    jest.doMock('../../src/utils/mcp-discovery', () => ({
+      discoverParentMcps: jest.fn(() => null)
+    }));
+    jest.doMock('../../src/utils/session-lock', () => ({
+      acquireLock: jest.fn(),
+      releaseLock: jest.fn()
+    }));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.resetModules();
+  });
+
+  it('rejects includeContext true with the default current session', async () => {
+    const { startSidecar } = require('../../src/sidecar/start');
+
+    await expect(startSidecar({
+      model: 'gemini',
+      prompt: 'test',
+      noUi: true,
+      cwd: repoRoot,
+      includeContext: true
+    })).rejects.toThrow(/exact/i);
+  });
+});
+
 describe('startSidecar includeContext option', () => {
   let buildContextMock;
 
@@ -307,7 +378,7 @@ describe('startSidecar includeContext option', () => {
   it('calls buildContext when includeContext is true', async () => {
     const { startSidecar } = require('../../src/sidecar/start');
     await startSidecar({
-      model: 'gemini', prompt: 'test', noUi: true, includeContext: true
+      model: 'gemini', prompt: 'test', noUi: true, includeContext: true, sessionId: 'session-a'
     });
     expect(buildContextMock).toHaveBeenCalled();
   });

--- a/tests/sidecar/start.test.js
+++ b/tests/sidecar/start.test.js
@@ -316,6 +316,33 @@ describe('startSidecar context binding validation', () => {
       includeContext: true
     })).rejects.toThrow(/exact/i);
   });
+
+  it('rejects includeContext true with sessionDir but no exact session id', async () => {
+    const { startSidecar } = require('../../src/sidecar/start');
+
+    await expect(startSidecar({
+      model: 'gemini',
+      prompt: 'test',
+      noUi: true,
+      cwd: repoRoot,
+      includeContext: true,
+      sessionDir: path.join(repoRoot, '.claude', 'sidecar_sessions')
+    })).rejects.toThrow(/exact/i);
+  });
+
+  it('rejects includeContext true with sessionDir and current session', async () => {
+    const { startSidecar } = require('../../src/sidecar/start');
+
+    await expect(startSidecar({
+      model: 'gemini',
+      prompt: 'test',
+      noUi: true,
+      cwd: repoRoot,
+      includeContext: true,
+      session: 'current',
+      sessionDir: path.join(repoRoot, '.claude', 'sidecar_sessions')
+    })).rejects.toThrow(/exact/i);
+  });
 });
 
 describe('startSidecar includeContext option', () => {

--- a/tests/sidecar/start.test.js
+++ b/tests/sidecar/start.test.js
@@ -245,6 +245,32 @@ describe('createSessionMetadata PID preservation', () => {
     expect(result.status).toBe('running');
     expect(result.createdAt).toBeDefined();
   });
+
+  it('rejects a symlinked sessions root before writing metadata outside the project', () => {
+    const { createSessionMetadata } = require('../../src/sidecar/start');
+    const projectDir = path.join(tmpDir, 'project');
+    const outsideRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'start-outside-sessions-'));
+    const claudeDir = path.join(projectDir, '.claude');
+
+    try {
+      fs.mkdirSync(claudeDir, { recursive: true });
+      fs.symlinkSync(outsideRoot, path.join(claudeDir, 'sidecar_sessions'), 'dir');
+
+      expect(() => {
+        createSessionMetadata('root-escape', projectDir, {
+          model: 'opus',
+          prompt: 'review code',
+          noUi: true,
+          agent: 'build',
+          thinking: 'medium'
+        });
+      }).toThrow(/sidecar sessions root|symbolic link|outside/i);
+
+      expect(fs.existsSync(path.join(outsideRoot, 'root-escape', 'metadata.json'))).toBe(false);
+    } finally {
+      fs.rmSync(outsideRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('startSidecar context binding validation', () => {
@@ -390,6 +416,11 @@ describe('startSidecar includeContext option', () => {
       assertContextBinding: jest.fn(),
       defaultIncludeContext: jest.fn(() => false),
       validateProjectPath: jest.fn((project) => project)
+    }));
+    jest.mock('../../src/utils/sidecar-session-boundaries', () => ({
+      ensureSidecarSessionDir: jest.fn(() => '/tmp/test-session'),
+      readContainedSessionFile: jest.fn(() => '{}'),
+      writeContainedSessionFile: jest.fn()
     }));
     jest.mock('fs', () => ({
       ...jest.requireActual('fs'),

--- a/tests/sidecar/start.test.js
+++ b/tests/sidecar/start.test.js
@@ -288,6 +288,11 @@ describe('startSidecar includeContext option', () => {
     jest.mock('../../src/utils/mcp-discovery', () => ({
       discoverParentMcps: jest.fn(() => null)
     }));
+    jest.mock('../../src/utils/sidecar-boundaries', () => ({
+      assertContextBinding: jest.fn(),
+      defaultIncludeContext: jest.fn(() => false),
+      validateProjectPath: jest.fn((project) => project)
+    }));
     jest.mock('fs', () => ({
       ...jest.requireActual('fs'),
       existsSync: jest.fn(() => false),
@@ -307,12 +312,15 @@ describe('startSidecar includeContext option', () => {
     expect(buildContextMock).toHaveBeenCalled();
   });
 
-  it('calls buildContext when includeContext is omitted (default true)', async () => {
+  it('skips buildContext when includeContext is omitted (default false)', async () => {
     const { startSidecar } = require('../../src/sidecar/start');
+    const { buildPrompts } = require('../../src/prompt-builder');
     await startSidecar({
       model: 'gemini', prompt: 'test', noUi: true
     });
-    expect(buildContextMock).toHaveBeenCalled();
+    expect(buildContextMock).not.toHaveBeenCalled();
+    const contextArg = buildPrompts.mock.calls[0][1];
+    expect(contextArg).toContain('Context excluded');
   });
 
   it('skips buildContext when includeContext is false', async () => {

--- a/tests/subagents/codex-event-normalizer.test.js
+++ b/tests/subagents/codex-event-normalizer.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const {
+  parseCodexJsonLine,
+  normalizeCodexEvent,
+  getFinalSummary,
+} = require('../../src/subagents/codex-event-normalizer');
+
+describe('codex-event-normalizer', () => {
+  test('returns null for blank lines', () => {
+    expect(parseCodexJsonLine('')).toBeNull();
+  });
+
+  test('throws for malformed JSON', () => {
+    expect(() => parseCodexJsonLine('{oops')).toThrow(/codex json/i);
+  });
+
+  test('parses a valid codex json line', () => {
+    const parsed = parseCodexJsonLine('{"type":"turn.started"}');
+    expect(parsed).toEqual({ type: 'turn.started' });
+  });
+
+  test('maps observed agent_message item into assistant content', () => {
+    const event = {
+      type: 'item.completed',
+      item: {
+        id: 'item_1',
+        type: 'agent_message',
+        text: 'READY'
+      }
+    };
+
+    expect(normalizeCodexEvent(event)).toEqual({
+      kind: 'assistant_text',
+      content: 'READY'
+    });
+  });
+
+  test('maps observed command_execution item into a tool-use style entry', () => {
+    const event = {
+      type: 'item.completed',
+      item: {
+        id: 'item_3',
+        type: 'command_execution',
+        command: '/bin/zsh -lc "printf \'READY\\\\n\' > /tmp/sidecar-codex-probe.txt"',
+        aggregated_output: '',
+        exit_code: 0,
+        status: 'completed'
+      }
+    };
+
+    expect(normalizeCodexEvent(event)).toEqual({
+      kind: 'tool_use',
+      toolCall: {
+        name: 'command_execution',
+        input: {
+          command: '/bin/zsh -lc "printf \'READY\\\\n\' > /tmp/sidecar-codex-probe.txt"',
+          exitCode: 0,
+          status: 'completed'
+        }
+      }
+    });
+  });
+
+  test('ignores non-content lifecycle events', () => {
+    expect(normalizeCodexEvent({ type: 'thread.started', thread_id: 'abc' })).toBeNull();
+    expect(normalizeCodexEvent({ type: 'turn.started' })).toBeNull();
+  });
+
+  test('returns the final summary from an observed final message event', () => {
+    const event = {
+      type: 'item.completed',
+      item: {
+        id: 'item_5',
+        type: 'agent_message',
+        text: 'done'
+      }
+    };
+
+    expect(getFinalSummary(event)).toBe('done');
+  });
+});

--- a/tests/subagents/codex-runner.test.js
+++ b/tests/subagents/codex-runner.test.js
@@ -79,7 +79,10 @@ describe('codex-runner', () => {
           process.nextTick(() => child.emit('close', 1));
           return child;
         }),
-        execFile: jest.fn((cmd, args, cb) => cb(null, '', '')),
+        execFile: jest.fn((cmd, args, options, cb) => {
+          const callback = typeof options === 'function' ? options : cb;
+          callback(null, '', '');
+        }),
       }));
 
       jest.doMock('readline', () => ({
@@ -125,7 +128,10 @@ describe('codex-runner', () => {
             process.nextTick(() => child.emit('close', 1));
             return child;
           }),
-          execFile: jest.fn((cmd, args, cb) => cb(null, '', '')),
+          execFile: jest.fn((cmd, args, options, cb) => {
+            const callback = typeof options === 'function' ? options : cb;
+            callback(null, '', '');
+          }),
         }));
 
         const { runCodexSubagent } = require('../../src/subagents/codex-runner');
@@ -150,6 +156,41 @@ describe('codex-runner', () => {
     }
   });
 
+  test('checks codex availability with sanitized env instead of ambient secrets', async () => {
+    const originalEnv = { ...process.env };
+    let capturedOptions;
+
+    try {
+      process.env.AWS_SECRET_ACCESS_KEY = 'aws-secret';
+      process.env.OPENAI_API_KEY = 'openai-secret';
+      process.env.SIDECAR_ENV_DIR = path.join(os.tmpdir(), 'sidecar-env-dir');
+
+      await jest.isolateModulesAsync(async () => {
+        jest.doMock('child_process', () => ({
+          spawn: jest.fn(),
+          execFile: jest.fn((_cmd, _args, options, cb) => {
+            capturedOptions = options;
+            const callback = typeof options === 'function' ? options : cb;
+            callback(null, '', '');
+          }),
+        }));
+
+        const { assertCodexAvailable } = require('../../src/subagents/codex-runner');
+        await assertCodexAvailable();
+      });
+
+      expect(capturedOptions).toEqual(expect.objectContaining({
+        env: expect.any(Object)
+      }));
+      expect(capturedOptions.env.PATH).toBe(process.env.PATH);
+      expect(capturedOptions.env.SIDECAR_ENV_DIR).toBe(process.env.SIDECAR_ENV_DIR);
+      expect(capturedOptions.env.AWS_SECRET_ACCESS_KEY).toBeUndefined();
+      expect(capturedOptions.env.OPENAI_API_KEY).toBeUndefined();
+    } finally {
+      process.env = originalEnv;
+    }
+  });
+
   test('rejects parent session directories without metadata', async () => {
     await jest.isolateModulesAsync(async () => {
       jest.doMock('child_process', () => ({
@@ -160,7 +201,10 @@ describe('codex-runner', () => {
           child.stdin = { end: jest.fn() };
           return child;
         }),
-        execFile: jest.fn((cmd, args, cb) => cb(null, '', '')),
+        execFile: jest.fn((cmd, args, options, cb) => {
+          const callback = typeof options === 'function' ? options : cb;
+          callback(null, '', '');
+        }),
       }));
 
       const { startCodexSubagent } = require('../../src/subagents/codex-runner');
@@ -190,7 +234,10 @@ describe('codex-runner', () => {
           });
           return child;
         }),
-        execFile: jest.fn((cmd, args, cb) => cb(null, '', '')),
+        execFile: jest.fn((cmd, args, options, cb) => {
+          const callback = typeof options === 'function' ? options : cb;
+          callback(null, '', '');
+        }),
       }));
 
       const { runCodexSubagent } = require('../../src/subagents/codex-runner');
@@ -230,7 +277,10 @@ describe('codex-runner', () => {
           });
           return child;
         }),
-        execFile: jest.fn((cmd, args, cb) => cb(null, '', '')),
+        execFile: jest.fn((cmd, args, options, cb) => {
+          const callback = typeof options === 'function' ? options : cb;
+          callback(null, '', '');
+        }),
       }));
 
       const { runCodexSubagent } = require('../../src/subagents/codex-runner');

--- a/tests/subagents/codex-runner.test.js
+++ b/tests/subagents/codex-runner.test.js
@@ -301,4 +301,64 @@ describe('codex-runner', () => {
     expect(metadata.status).toBe('error');
     expect(metadata.reason).toContain('codex failed');
   });
+
+  test('does not append codex stderr through a symlinked stderr log', async () => {
+    writeParentMetadata();
+    const outsideTarget = path.join(tempDir, 'outside-codex-stderr.log');
+    fs.writeFileSync(outsideTarget, 'outside-original');
+
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('child_process', () => ({
+        spawn: jest.fn(() => {
+          const child = new EventEmitter();
+          child.stdout = new EventEmitter();
+          child.stderr = new EventEmitter();
+          child.stdin = { end: jest.fn() };
+          process.nextTick(() => {
+            const stderrPath = path.join(
+              projectDir,
+              '.claude',
+              'sidecar_sessions',
+              'parent-task',
+              'subagents',
+              'subagent-stderr-symlink',
+              'codex-stderr.log'
+            );
+            fs.symlinkSync(outsideTarget, stderrPath);
+            child.stderr.emit('data', Buffer.from('codex failed'));
+            child.emit('close', 1);
+          });
+          return child;
+        }),
+        execFile: jest.fn((cmd, args, options, cb) => {
+          const callback = typeof options === 'function' ? options : cb;
+          callback(null, '', '');
+        }),
+      }));
+
+      const { runCodexSubagent } = require('../../src/subagents/codex-runner');
+      await runCodexSubagent({
+        projectDir,
+        parentTaskId: 'parent-task',
+        subagentId: 'subagent-stderr-symlink',
+        briefing: 'Fix auth flow',
+        agentType: 'build'
+      });
+    });
+
+    const metadataPath = path.join(
+      projectDir,
+      '.claude',
+      'sidecar_sessions',
+      'parent-task',
+      'subagents',
+      'subagent-stderr-symlink',
+      'metadata.json'
+    );
+
+    expect(fs.readFileSync(outsideTarget, 'utf-8')).toBe('outside-original');
+    const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf-8'));
+    expect(metadata.status).toBe('error');
+    expect(metadata.reason).toContain('codex failed');
+  });
 });

--- a/tests/subagents/codex-runner.test.js
+++ b/tests/subagents/codex-runner.test.js
@@ -86,7 +86,7 @@ describe('codex-runner', () => {
     });
 
     expect(capturedArgs).toEqual(expect.arrayContaining([
-      'codex', 'exec', '--json', '--sandbox', 'read-only', '-C', projectDir, '-'
+      'codex', 'exec', '--json', '--sandbox', 'read-only', '-C', fs.realpathSync(projectDir), '-'
     ]));
   });
 

--- a/tests/subagents/codex-runner.test.js
+++ b/tests/subagents/codex-runner.test.js
@@ -21,6 +21,18 @@ describe('codex-runner', () => {
     jest.clearAllMocks();
   });
 
+  function writeParentMetadata() {
+    fs.writeFileSync(
+      path.join(projectDir, '.claude', 'sidecar_sessions', 'parent-task', 'metadata.json'),
+      JSON.stringify({
+        taskId: 'parent-task',
+        project: fs.realpathSync(projectDir),
+        projectDir: fs.realpathSync(projectDir),
+        status: 'running'
+      })
+    );
+  }
+
   test('maps plan to read-only sandbox', () => {
     const { resolveSandboxMode } = require('../../src/subagents/codex-runner');
     expect(resolveSandboxMode('plan')).toBe('read-only');
@@ -54,6 +66,7 @@ describe('codex-runner', () => {
 
   test('spawns codex exec with the expected args for explore', async () => {
     let capturedArgs;
+    writeParentMetadata();
 
     await jest.isolateModulesAsync(async () => {
       jest.doMock('child_process', () => ({
@@ -90,7 +103,33 @@ describe('codex-runner', () => {
     ]));
   });
 
+  test('rejects parent session directories without metadata', async () => {
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('child_process', () => ({
+        spawn: jest.fn(() => {
+          const child = new EventEmitter();
+          child.stdout = new EventEmitter();
+          child.stderr = new EventEmitter();
+          child.stdin = { end: jest.fn() };
+          return child;
+        }),
+        execFile: jest.fn((cmd, args, cb) => cb(null, '', '')),
+      }));
+
+      const { startCodexSubagent } = require('../../src/subagents/codex-runner');
+      await expect(startCodexSubagent({
+        projectDir,
+        parentTaskId: 'parent-task',
+        subagentId: 'subagent-no-parent-metadata',
+        briefing: 'Inspect auth flow',
+        agentType: 'explore'
+      })).rejects.toThrow(/metadata|parent session/i);
+    });
+  });
+
   test('writes summary.md and marks metadata complete on a successful final event', async () => {
+    writeParentMetadata();
+
     await jest.isolateModulesAsync(async () => {
       jest.doMock('child_process', () => ({
         spawn: jest.fn(() => {
@@ -129,6 +168,8 @@ describe('codex-runner', () => {
   });
 
   test('marks metadata error when codex exits non-zero', async () => {
+    writeParentMetadata();
+
     await jest.isolateModulesAsync(async () => {
       jest.doMock('child_process', () => ({
         spawn: jest.fn(() => {

--- a/tests/subagents/codex-runner.test.js
+++ b/tests/subagents/codex-runner.test.js
@@ -103,6 +103,53 @@ describe('codex-runner', () => {
     ]));
   });
 
+  test('spawns codex with sanitized env instead of inheriting ambient secrets', async () => {
+    const originalEnv = { ...process.env };
+    let capturedEnv;
+    writeParentMetadata();
+
+    try {
+      process.env.AWS_SECRET_ACCESS_KEY = 'aws-secret';
+      process.env.OPENAI_API_KEY = 'openai-secret';
+      process.env.ANTHROPIC_API_KEY = 'anthropic-secret';
+      process.env.SIDECAR_ENV_DIR = path.join(os.tmpdir(), 'sidecar-env-dir');
+
+      await jest.isolateModulesAsync(async () => {
+        jest.doMock('child_process', () => ({
+          spawn: jest.fn((cmd, args, options) => {
+            capturedEnv = options.env;
+            const child = new EventEmitter();
+            child.stdout = new EventEmitter();
+            child.stderr = new EventEmitter();
+            child.stdin = { end: jest.fn() };
+            process.nextTick(() => child.emit('close', 1));
+            return child;
+          }),
+          execFile: jest.fn((cmd, args, cb) => cb(null, '', '')),
+        }));
+
+        const { runCodexSubagent } = require('../../src/subagents/codex-runner');
+        await runCodexSubagent({
+          projectDir,
+          parentTaskId: 'parent-task',
+          subagentId: 'subagent-env',
+          briefing: 'Inspect auth flow',
+          agentType: 'explore'
+        });
+      });
+
+      expect(capturedEnv).toBeDefined();
+      expect(capturedEnv.PATH).toBe(process.env.PATH);
+      expect(capturedEnv.HOME).toBe(process.env.HOME);
+      expect(capturedEnv.SIDECAR_ENV_DIR).toBe(process.env.SIDECAR_ENV_DIR);
+      expect(capturedEnv.AWS_SECRET_ACCESS_KEY).toBeUndefined();
+      expect(capturedEnv.OPENAI_API_KEY).toBeUndefined();
+      expect(capturedEnv.ANTHROPIC_API_KEY).toBeUndefined();
+    } finally {
+      process.env = originalEnv;
+    }
+  });
+
   test('rejects parent session directories without metadata', async () => {
     await jest.isolateModulesAsync(async () => {
       jest.doMock('child_process', () => ({

--- a/tests/subagents/codex-runner.test.js
+++ b/tests/subagents/codex-runner.test.js
@@ -1,0 +1,166 @@
+'use strict';
+
+const EventEmitter = require('events');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+describe('codex-runner', () => {
+  let tempDir;
+  let projectDir;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidecar-codex-runner-'));
+    projectDir = tempDir;
+    fs.mkdirSync(path.join(projectDir, '.claude', 'sidecar_sessions', 'parent-task'), { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  test('maps plan to read-only sandbox', () => {
+    const { resolveSandboxMode } = require('../../src/subagents/codex-runner');
+    expect(resolveSandboxMode('plan')).toBe('read-only');
+  });
+
+  test('maps explore to read-only sandbox', () => {
+    const { resolveSandboxMode } = require('../../src/subagents/codex-runner');
+    expect(resolveSandboxMode('explore')).toBe('read-only');
+  });
+
+  test('maps build to workspace-write sandbox', () => {
+    const { resolveSandboxMode } = require('../../src/subagents/codex-runner');
+    expect(resolveSandboxMode('build')).toBe('workspace-write');
+  });
+
+  test('maps general to workspace-write sandbox', () => {
+    const { resolveSandboxMode } = require('../../src/subagents/codex-runner');
+    expect(resolveSandboxMode('general')).toBe('workspace-write');
+  });
+
+  test('rejects chat because codex exec is non-interactive', () => {
+    const { resolveSandboxMode } = require('../../src/subagents/codex-runner');
+    expect(() => resolveSandboxMode('chat')).toThrow(/interactive chat/i);
+  });
+
+  test('prepends the expected role adder to the briefing', () => {
+    const { addRolePreamble } = require('../../src/subagents/codex-runner');
+    expect(addRolePreamble('plan', 'Check auth race')).toContain('ROLE: Plan.');
+    expect(addRolePreamble('build', 'Fix auth race')).toContain('ROLE: Build.');
+  });
+
+  test('spawns codex exec with the expected args for explore', async () => {
+    let capturedArgs;
+
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('child_process', () => ({
+        spawn: jest.fn((cmd, args) => {
+          capturedArgs = [cmd, ...args];
+          const child = new EventEmitter();
+          child.stdout = new EventEmitter();
+          child.stderr = new EventEmitter();
+          child.stdin = { end: jest.fn() };
+          process.nextTick(() => child.emit('close', 1));
+          return child;
+        }),
+        execFile: jest.fn((cmd, args, cb) => cb(null, '', '')),
+      }));
+
+      jest.doMock('readline', () => ({
+        createInterface: jest.fn(() => ({
+          [Symbol.asyncIterator]: async function* () {}
+        }))
+      }));
+
+      const { runCodexSubagent } = require('../../src/subagents/codex-runner');
+      await runCodexSubagent({
+        projectDir,
+        parentTaskId: 'parent-task',
+        subagentId: 'subagent-1',
+        briefing: 'Inspect auth flow',
+        agentType: 'explore'
+      });
+    });
+
+    expect(capturedArgs).toEqual(expect.arrayContaining([
+      'codex', 'exec', '--json', '--sandbox', 'read-only', '-C', projectDir, '-'
+    ]));
+  });
+
+  test('writes summary.md and marks metadata complete on a successful final event', async () => {
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('child_process', () => ({
+        spawn: jest.fn(() => {
+          const child = new EventEmitter();
+          child.stdout = new EventEmitter();
+          child.stderr = new EventEmitter();
+          child.stdin = { end: jest.fn() };
+          process.nextTick(() => {
+            child.stdout.emit('data', Buffer.from('{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"done"}}\n'));
+            child.emit('close', 0);
+          });
+          return child;
+        }),
+        execFile: jest.fn((cmd, args, cb) => cb(null, '', '')),
+      }));
+
+      const { runCodexSubagent } = require('../../src/subagents/codex-runner');
+      await runCodexSubagent({
+        projectDir,
+        parentTaskId: 'parent-task',
+        subagentId: 'subagent-2',
+        briefing: 'Inspect auth flow',
+        agentType: 'plan'
+      });
+    });
+
+    const summaryPath = path.join(
+      projectDir, '.claude', 'sidecar_sessions', 'parent-task', 'subagents', 'subagent-2', 'summary.md'
+    );
+    const metadataPath = path.join(
+      projectDir, '.claude', 'sidecar_sessions', 'parent-task', 'subagents', 'subagent-2', 'metadata.json'
+    );
+
+    expect(fs.readFileSync(summaryPath, 'utf-8')).toContain('done');
+    expect(JSON.parse(fs.readFileSync(metadataPath, 'utf-8')).status).toBe('complete');
+  });
+
+  test('marks metadata error when codex exits non-zero', async () => {
+    await jest.isolateModulesAsync(async () => {
+      jest.doMock('child_process', () => ({
+        spawn: jest.fn(() => {
+          const child = new EventEmitter();
+          child.stdout = new EventEmitter();
+          child.stderr = new EventEmitter();
+          child.stdin = { end: jest.fn() };
+          process.nextTick(() => {
+            child.stderr.emit('data', Buffer.from('codex failed'));
+            child.emit('close', 1);
+          });
+          return child;
+        }),
+        execFile: jest.fn((cmd, args, cb) => cb(null, '', '')),
+      }));
+
+      const { runCodexSubagent } = require('../../src/subagents/codex-runner');
+      await runCodexSubagent({
+        projectDir,
+        parentTaskId: 'parent-task',
+        subagentId: 'subagent-3',
+        briefing: 'Fix auth flow',
+        agentType: 'build'
+      });
+    });
+
+    const metadataPath = path.join(
+      projectDir, '.claude', 'sidecar_sessions', 'parent-task', 'subagents', 'subagent-3', 'metadata.json'
+    );
+
+    const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf-8'));
+    expect(metadata.status).toBe('error');
+    expect(metadata.reason).toContain('codex failed');
+  });
+});


### PR DESCRIPTION
## Summary
- Restrict sidecar workspace/session/context boundaries.
- Prevent ambient provider secret inheritance and harden .env permissions.
- Align e2e temp projects with explicit allowed roots.

## Test Plan
- npm test -- --runInBand (1708 passed, 2 skipped)
- npm run lint
- node scripts/validate-docs.js --full
- npm test -- e2e.test.js --runInBand (13 passed)
- Targeted boundary/security suites recorded in execution notes